### PR TITLE
feat: support ignore file (e.g. `.gitignore`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ interface FingerprintOptions {
   exclude?: string[];      // Glob patterns to exclude
   extraInputs?: FingerprintInput[];  // Additional inputs: content, JSON
   hashAlgorithm?: 'sha1' | 'sha256' | 'sha512';  // Hash algorithm (default: sha1)
-  ignoreFilePath?: string // Path to ignore file, e.g. ".gitignore" (relative to "rootDir")
+  gitIgnorePath?: string | null // Path to ignore file, e.g. ".gitignore" (relative to "rootDir")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ Main function that generates a fingerprint for filesystem entries.
 
 ```typescript
 interface FingerprintOptions {
-  include?: string[];      // Files and directories include (default: all) - NOTE: this are not glob patterns
+  include?: string[];      // Files and directories to include (default: all) - NOTE: this are NOT a glob patterns
   exclude?: string[];      // Glob patterns to exclude
-  extraInputs?: FingerprintInput[];  // Additional content/JSON inputs
-  hashAlgorithm?: 'sha1' | 'sha256' | 'sha512';  // Hash algorithm (default: sha256)
+  extraInputs?: FingerprintInput[];  // Additional inputs: content, JSON
+  hashAlgorithm?: 'sha1' | 'sha256' | 'sha512';  // Hash algorithm (default: sha1)
+  ignoreFilePath?: string // Path to ignore file, e.g. ".gitignore" (relative to "rootDir")
 }
 ```
 

--- a/benchmarks/fingerprint.bench.ts
+++ b/benchmarks/fingerprint.bench.ts
@@ -62,7 +62,7 @@ async function runBenchmarks(): Promise<void> {
   
   // React Native benchmarks
   const reactNativeOptions: FingerprintOptions = {
-    include: ["android","ios", "package.json", "README.md"],
+    include: ["packages", "package.json", "README.md"],
     exclude: ["**/node_modules/**", "**/.git/**"],
   }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "release": "release-it"
   },
   "dependencies": {
+    "ignore": "^7.0.5",
     "micromatch": "^4.0.8",
     "p-limit": "^7.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      ignore:
+        specifier: ^7.0.5
+        version: 7.0.5
       micromatch:
         specifier: ^4.0.8
         version: 4.0.8

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -177,7 +177,7 @@ test("calculate fingerprint supports .gitignore", async () => {
     include: ["test1.txt", "dir"],
     exclude: ["**/*.ts"],
     hashAlgorithm: "sha1",
-    ignoreFilePath: ".gitignore",
+    gitIgnorePath: ".gitignore",
   }
 
   const fingerprintSync = calculateFingerprintSync(rootDir, options);
@@ -200,6 +200,41 @@ test("calculate fingerprint supports .gitignore", async () => {
   expect(findInput(fingerprint.inputs, "dir/test4.ts")).toBeNull(); // exclude option
   expect(findInput(fingerprint.inputs, "dir/nested/test5.txt")).toBeTruthy();
   expect(findInput(fingerprint.inputs, "dir/nested/test6.md")).toBeNull(); // .gitignore
+});
+
+test("calculate fingerprint custom ignore file", async () => {
+  writeFile("test1.txt", "Hello, world!");
+  writeFile("dir/test2.txt", "Hellow world");
+  writeFile("dir/test3.md", "Should be ignored");
+  writeFile("dir/nested/test4.txt", "Hello, there!");
+  writeFile("dir/nested/test5.md", "Should be ignored");
+  writeFile(".my-ignore", "**/*.md");
+
+  const options: FingerprintOptions = {
+    include: ["test1.txt", "dir"],
+    hashAlgorithm: "sha1",
+    gitIgnorePath: ".my-ignore",
+  }
+
+  const fingerprintSync = calculateFingerprintSync(rootDir, options);
+  const fingerprint = await calculateFingerprint(rootDir, options);
+  expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
+    "Hash: ae2b2ff7ab1c6c2d1060220dc6361b42b6693719
+    Inputs:
+      - DIRECTORY dir - 59ca50cbe3091cc5a9ec216fb5dcd75ea9bd8475
+          - DIRECTORY dir/nested - 7290c0cbea4da413147d8cdfd238b1f4c7b68642
+              - FILE dir/nested/test4.txt - f84640c76bd37e72446bc21d36613c3bb38dd788
+          - FILE dir/test2.txt - 35a883d254566ac9d9a375e5d3307fb0765d9e18
+      - FILE test1.txt - 943a702d06f34599aee1f8da8ef9f7296031d699
+    "
+  `);
+  
+  expect(fingerprintSync).toEqual(fingerprint);
+  expect(findInput(fingerprint.inputs, "test1.txt")).toBeTruthy();
+  expect(findInput(fingerprint.inputs, "dir/test2.txt")).toBeTruthy();
+  expect(findInput(fingerprint.inputs, "dir/test3.md")).toBeNull(); // .gitignore
+  expect(findInput(fingerprint.inputs, "dir/nested/test4.txt")).toBeTruthy();
+  expect(findInput(fingerprint.inputs, "dir/nested/test5.md")).toBeNull(); // .gitignore
 });
 
 function writeFile(filePath: string, content: string) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,4 @@
 export const EMPTY_HASH = "(null)";
 export const DEFAULT_HASH_ALGORITHM = "sha1";
+export const DEFAULT_CONCURRENCY = 16;
+export const DEFAULT_GIT_IGNORE_PATH = ".gitignore";

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -27,7 +27,7 @@ export async function calculateFingerprint(
     rootDir,
     exclude: options?.exclude,
     hashAlgorithm: options?.hashAlgorithm,
-    ignoreObject: buildIgnoreObject(rootDir, options?.ignoreFilePath),
+    ignoreObject: buildIgnoreObject(rootDir, options?.gitIgnorePath),
     asyncWrapper: pLimit(options?.maxConcurrent ?? DEFAULT_CONCURRENCY),
   };
 
@@ -120,7 +120,7 @@ export function calculateFingerprintSync(
     rootDir,
     exclude: options?.exclude,
     hashAlgorithm: options?.hashAlgorithm,
-    ignoreObject: buildIgnoreObject(rootDir, options?.ignoreFilePath),
+    ignoreObject: buildIgnoreObject(rootDir, options?.gitIgnorePath),
   };
 
   const inputHashes: FingerprintInputHash[] = [];
@@ -210,9 +210,9 @@ function calculateEntryHashForDirentSync(
   }
 }
 
-function buildIgnoreObject(rootDir: string, gitIgnorePath: string | undefined): Ignore | null {
+function buildIgnoreObject(rootDir: string, gitIgnorePath: string | null = ".gitignore"): Ignore | undefined {
   if (gitIgnorePath == null) {
-    return null;
+    return undefined;
   }
 
   const rules = readFileSync(path.join(rootDir, gitIgnorePath), "utf8")

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -215,6 +215,12 @@ function buildIgnoreObject(rootDir: string, gitIgnorePath: string | null = ".git
     return undefined;
   }
 
-  const rules = readFileSync(path.join(rootDir, gitIgnorePath), "utf8")
+  let rules: string;
+  try {
+    rules = readFileSync(path.join(rootDir, gitIgnorePath), "utf8")
+  } catch {
+    return undefined;
+  }
+
   return ignore().add(rules);
 }

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -15,7 +15,7 @@ import type {
   FingerprintOptions,
   FingerprintResult,
 } from "./types.js";
-import { matchesAnyPattern, mergeHashes } from "./utils.js";
+import { isExcludedPath, mergeHashes } from "./utils.js";
 
 const DEFAULT_CONCURRENCY = 16;
 
@@ -71,18 +71,16 @@ async function calculateEntryHashForDirent(
   entry: Dirent,
   config: FingerprintConfig
 ): Promise<FingerprintInputHash | null> {
-  const entryPath = entry.name;
-  const shouldBeExcluded = matchesAnyPattern(entryPath, config.exclude) || config.ignoreObject?.ignores(entryPath);
-  if (shouldBeExcluded) {
+  if (isExcludedPath(entry.name, config)) {
     return null;
   }
 
   if (entry.isFile()) {
-    return calculateFileHash(entryPath, config);
+    return calculateFileHash(entry.name, config);
   } else if (entry.isDirectory()) {
-    return calculateDirectoryHash(entryPath, config);
+    return calculateDirectoryHash(entry.name, config);
   } else {
-    console.warn(`fs-fingerprint: skipping ${entryPath} (not a file or directory)`);
+    console.warn(`fs-fingerprint: skipping ${entry.name} (not a file or directory)`);
     return null;
   }
 }
@@ -91,8 +89,7 @@ async function calculateEntryHashForPath(
   entryPath: string,
   config: FingerprintConfig
 ): Promise<FingerprintInputHash | null> {
-  const shouldBeExcluded = matchesAnyPattern(entryPath, config.exclude) || config.ignoreObject?.ignores(entryPath);
-  if (shouldBeExcluded) {
+  if (isExcludedPath(entryPath, config)) {
     return null;
   }
 
@@ -169,8 +166,7 @@ function calculateEntryHashForPathSync(
   entryPath: string,
   config: FingerprintConfig
 ): FingerprintInputHash | null {
-  const shouldBeExcluded = matchesAnyPattern(entryPath, config.exclude) || config.ignoreObject?.ignores(entryPath);
-  if (shouldBeExcluded) {
+  if (isExcludedPath(entryPath, config)) {
     return null;
   }
 
@@ -198,8 +194,7 @@ function calculateEntryHashForDirentSync(
   config: FingerprintConfig
 ): FingerprintInputHash | null {
   const entryPath = entry.name;
-  const shouldBeExcluded = matchesAnyPattern(entryPath, config?.exclude) || config.ignoreObject?.ignores(entryPath);
-  if (shouldBeExcluded) {
+  if (isExcludedPath(entryPath, config)) {
     return null;
   }
 

--- a/src/inputs/directory.ts
+++ b/src/inputs/directory.ts
@@ -3,18 +3,18 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { FingerprintConfig, FingerprintDirectoryHash } from "../types.js";
-import { matchesAnyPattern, mergeHashes } from "../utils.js";
+import { isExcludedPath, mergeHashes } from "../utils.js";
 import { calculateFileHash,calculateFileHashSync } from "./file.js";
 
 export async function calculateDirectoryHash(
   path: string,
   config: FingerprintConfig
 ): Promise<FingerprintDirectoryHash | null> {
-  const pathWithRoot = join(config.rootDir, path);
-  if (matchesAnyPattern(path, config.exclude) || config.ignoreObject?.ignores(path)) {
+  if (isExcludedPath(path, config)) {
     return null;
   }
 
+  const pathWithRoot = join(config.rootDir, path);
   const entries = await readdir(pathWithRoot, { withFileTypes: true });
   const entryHashes = await Promise.all(entries
     .map((entry) => {
@@ -45,11 +45,11 @@ export function calculateDirectoryHashSync(
   path: string,
   config: FingerprintConfig
 ): FingerprintDirectoryHash | null {
-  const pathWithRoot = join(config.rootDir, path);
-  if (matchesAnyPattern(path, config.exclude) || config.ignoreObject?.ignores(path)) {
+  if (isExcludedPath(path, config)) {
     return null;
   }
 
+  const pathWithRoot = join(config.rootDir, path);
   const entries = readdirSync(pathWithRoot, { withFileTypes: true });
   const entryHashes = entries
     .map((entry) => {

--- a/src/inputs/directory.ts
+++ b/src/inputs/directory.ts
@@ -11,7 +11,7 @@ export async function calculateDirectoryHash(
   config: FingerprintConfig
 ): Promise<FingerprintDirectoryHash | null> {
   const pathWithRoot = join(config.rootDir, path);
-  if (matchesAnyPattern(path, config.exclude)) {
+  if (matchesAnyPattern(path, config.exclude) || config.ignoreObject?.ignores(path)) {
     return null;
   }
 
@@ -46,7 +46,7 @@ export function calculateDirectoryHashSync(
   config: FingerprintConfig
 ): FingerprintDirectoryHash | null {
   const pathWithRoot = join(config.rootDir, path);
-  if (matchesAnyPattern(path, config.exclude)) {
+  if (matchesAnyPattern(path, config.exclude) || config.ignoreObject?.ignores(path)) {
     return null;
   }
 

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -4,13 +4,13 @@ import { join } from "node:path";
 
 import { EMPTY_HASH } from "../constants.js";
 import type { FingerprintConfig, FingerprintFileHash } from "../types.js";
-import { hashContent, matchesAnyPattern } from "../utils.js";
+import { hashContent, isExcludedPath } from "../utils.js";
 
 export async function calculateFileHash(
   path: string,
   config: FingerprintConfig
 ): Promise<FingerprintFileHash | null> {
-  if (matchesAnyPattern(path, config.exclude) || config.ignoreObject?.ignores(path)) {
+  if (isExcludedPath(path, config)) {
     return null;
   }
 
@@ -37,7 +37,7 @@ export function calculateFileHashSync(
   path: string,
   config: FingerprintConfig
 ): FingerprintFileHash | null {
-  if (matchesAnyPattern(path, config.exclude) || config.ignoreObject?.ignores(path)) {
+  if (isExcludedPath(path, config)) {
     return null;
   }
 

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -6,6 +6,8 @@ import { EMPTY_HASH } from "../constants.js";
 import type { FingerprintConfig, FingerprintFileHash } from "../types.js";
 import { hashContent, isExcludedPath } from "../utils.js";
 
+const noopWrapper = async (fn: () => PromiseLike<string>) => fn();
+
 export async function calculateFileHash(
   path: string,
   config: FingerprintConfig
@@ -23,8 +25,10 @@ export async function calculateFileHash(
     };
   }
 
+  const asyncWrapper = config.asyncWrapper ?? noopWrapper;
+
   const pathWithRoot = join(config.rootDir, path);
-  const content = config.asyncWrapper ? await config.asyncWrapper(() => readFile(pathWithRoot, "utf8")) : await readFile(pathWithRoot, "utf8");
+  const content = await asyncWrapper(() => readFile(pathWithRoot, "utf8"));
   return {
     type: "file",
     key: `file:${path}`,

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -10,7 +10,7 @@ export async function calculateFileHash(
   path: string,
   config: FingerprintConfig
 ): Promise<FingerprintFileHash | null> {
-  if (matchesAnyPattern(path, config.exclude)) {
+  if (matchesAnyPattern(path, config.exclude) || config.ignoreObject?.ignores(path)) {
     return null;
   }
 
@@ -37,7 +37,7 @@ export function calculateFileHashSync(
   path: string,
   config: FingerprintConfig
 ): FingerprintFileHash | null {
-  if (matchesAnyPattern(path, config.exclude)) {
+  if (matchesAnyPattern(path, config.exclude) || config.ignoreObject?.ignores(path)) {
     return null;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,20 +1,42 @@
-export type HashAlgorithm = "sha1" | "sha256" | "sha512" | "null";
+import type { Ignore } from "ignore";
+
+type StringWithAutoSuggest<T> = (string & {}) | T;
+
+/** Hashing algorithm to use */
+/**
+ * Hashing algorithm to use.
+ * Common values: "sha1", "sha256", "sha512", "null", etc.
+ * TypeScript will auto-suggest these values, but any string is allowed.
+ */
+export type HashAlgorithm = StringWithAutoSuggest<"sha1" | "sha256" | "sha512" | "null">;
 
 export type FingerprintOptions = {
+  /** Paths to include (does not support globs) */
   include?: readonly string[];
+
+  /** Paths to exclude (support globs, minimatch syntax) */
   exclude?: readonly string[];
+
+  /** Extra inputs to include in the fingerprint */
   extraInputs?: FingerprintInput[];
+  
+  /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;
-  maxConcurrency?: number;
+
+  /** Path (relative to rootDir) to ignore file, e.g. ".gitignore" */
+  ignoreFilePath?: string;
+
+  /** Maximum number of concurrently opened files */ 
+  maxConcurrent?: number;
 };
 
 export type AsyncWrapper = <T>(fn: () => PromiseLike<T> | T) => Promise<T>;
 
 export type FingerprintConfig = {
   rootDir: string;
-  include?: readonly string[];
   exclude?: readonly string[];
   hashAlgorithm?: HashAlgorithm;
+  ignoreObject: Ignore | null;
   asyncWrapper?: AsyncWrapper;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,8 +23,11 @@ export type FingerprintOptions = {
   /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;
 
-  /** Path (relative to rootDir) to ignore file, e.g. ".gitignore" */
-  ignoreFilePath?: string;
+  /** 
+   * Path (relative to rootDir) to ".gitignore"-like file.
+   * Defaults to ".gitignore". Set to `null` to disable.
+   */
+  gitIgnorePath?: string | null;
 
   /** Maximum number of concurrently opened files */ 
   maxConcurrent?: number;
@@ -36,7 +39,7 @@ export type FingerprintConfig = {
   rootDir: string;
   exclude?: readonly string[];
   hashAlgorithm?: HashAlgorithm;
-  ignoreObject: Ignore | null;
+  ignoreObject?: Ignore;
   asyncWrapper?: AsyncWrapper;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,13 +49,5 @@ export function mergeHashes(
 }
 
 export function isExcludedPath(path: string, config: FingerprintConfig): boolean {
-  return matchesAnyPattern(path, config.exclude) || (config.ignoreObject?.ignores(path) ?? false);
-}
-
-function matchesAnyPattern(path: string, patterns?: readonly string[]): boolean {
-  if (!patterns) {
-    return false;
-  }
-
-  return micromatch.isMatch(path, patterns);
+  return micromatch.isMatch(path, config.exclude ?? []) || (config.ignoreObject?.ignores(path) ?? false);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,7 +48,11 @@ export function mergeHashes(
   };
 }
 
-export function matchesAnyPattern(path: string, patterns?: readonly string[]): boolean {
+export function isExcludedPath(path: string, config: FingerprintConfig): boolean {
+  return matchesAnyPattern(path, config.exclude) || (config.ignoreObject?.ignores(path) ?? false);
+}
+
+function matchesAnyPattern(path: string, patterns?: readonly string[]): boolean {
   if (!patterns) {
     return false;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,5 +57,5 @@ function matchesAnyPattern(path: string, patterns?: readonly string[]): boolean 
     return false;
   }
 
-  return patterns.some((pattern) => micromatch.isMatch(path, pattern));
+  return micromatch.isMatch(path, patterns);
 }


### PR DESCRIPTION
## What does this PR do?

Adds support for git ignore files (e.g. `.gitingore`, `.fingerprintignore`, etc). 

```ts
calculateFingerprint(rootDir, { 
  gitIgnorePath: ".gitignore", // relative to "rootDir", default: ".gitignore"
}
```

## Relevant implementation details

## How did you test this?
