### PR TITLE
chore: output benchmark table as markdown

### DIFF
--- a/benchmarks/fingerprint.bench.ts
+++ b/benchmarks/fingerprint.bench.ts
@@ -174,40 +174,38 @@ async function runBenchmarks(): Promise<void> {
     );
 
     if (!baseline) {
-      return {
-        "Task name": current.name,
-        "Baseline latency (ms)": "N/A",
-        "Current latency (ms)": current.latency.p50?.toFixed(2) || "N/A",
-        "Change (ms)": "N/A",
-      };
+      return [current.name, "N/A", current.latency.p50?.toFixed(2) || "N/A", "N/A"];
     }
 
     const currentLatency = current.latency.p50;
     const baselineLatency = baseline.latency.p50;
 
     if (!currentLatency || !baselineLatency) {
-      return {
-        "Task name": current.name,
-        "Baseline latency (ms)": baselineLatency?.toFixed(2) || "N/A",
-        "Current latency (ms)": currentLatency?.toFixed(2) || "N/A",
-        "Change (ms)": "N/A",
-      };
+      return [
+        current.name,
+        baselineLatency?.toFixed(2) || "N/A",
+        currentLatency?.toFixed(2) || "N/A",
+        "N/A",
+      ];
     }
 
     const latencyChange = currentLatency - baselineLatency;
     const latencyChangePercent = (latencyChange / baselineLatency) * 100;
 
-    return {
-      "Task name": current.name,
-      "Baseline latency (ms)": baselineLatency.toFixed(2),
-      "Current latency (ms)": currentLatency.toFixed(2),
-      "Change (ms)": `${latencyChange > 0 ? "+" : ""}${latencyChange.toFixed(2)} (${
-        latencyChangePercent > 0 ? "+" : ""
-      }${latencyChangePercent.toFixed(1)}%)`,
-    };
+    return [
+      current.name,
+      baselineLatency.toFixed(2),
+      currentLatency.toFixed(2),
+      `${latencyChange > 0 ? "+" : ""}${latencyChange.toFixed(2)} (${latencyChangePercent > 0 ? "+" : ""}${latencyChangePercent.toFixed(1)}%)`,
+    ];
   });
 
-  console.table(comparisonTable);
+  console.log(
+    md.table(
+      ["Task name", "Baseline latency (ms)", "Current latency (ms)", "Change (ms)"],
+      comparisonTable,
+    ),
+  );
 }
 
 // Run benchmarks if this file is executed directly

--- a/benchmarks/fingerprint.bench.ts
+++ b/benchmarks/fingerprint.bench.ts
@@ -9,7 +9,6 @@ import {
   type FingerprintOptions,
 } from "../src/index.js";
 import { RepoManager } from "./fixtures/repos.js";
-import { table } from "ts-markdown-builder";
 
 const isBaseline = process.argv.includes("--baseline");
 

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "release-it": "^19.0.4",
         "rimraf": "^6.0.1",
         "tinybench": "^5.0.1",
+        "ts-markdown-builder": "^0.5.0",
         "tsup": "^8.5.0",
         "tsx": "^4.20.5",
         "typescript": "^5.9.2",
@@ -850,6 +851,8 @@
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "ts-markdown-builder": ["ts-markdown-builder@0.5.0", "", {}, "sha512-/2pzAFjGwk5fUR8ftFMhCOm/zmoqtpYWK6209j3YPfgWF2I+eYY6PKpR0mBJte6s8McnkQ/T92fV+IJg6bdxyw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "release-it": "^19.0.4",
     "rimraf": "^6.0.1",
     "tinybench": "^5.0.1",
+    "ts-markdown-builder": "^0.5.0",
     "tsup": "^8.5.0",
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",


### PR DESCRIPTION
## What does this PR do?

## Relevant implementation details

## How did you test this?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Benchmark results are now rendered as Markdown tables with clear headers, replacing console.table.
  - Outputs include Task, Latency, Throughput, Samples, and Change, with signed numeric and percentage deltas for baseline comparisons.
  - Consistent formatting applied across per-task and final comparison tables.

- Chores
  - Added ts-markdown-builder as a dependency for Markdown table generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->