### PR TITLE
feat: improve input API (BREAKING)

### DIFF
--- a/.github/workflows/pkg-size.yml
+++ b/.github/workflows/pkg-size.yml
@@ -1,4 +1,4 @@
-name: Check Package Size
+name: Package Size
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-size:
+  pkg-size:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ const { hash } = await calculateFingerprint({
 
 ```ts
 async function calculateFingerprint(options?: {
-  basePath: string; // Path to directory that the config applies to, if not provided, only `extraInputs` are considered
+  basePath: string; // Path to directory that the config applies to, if not provided, only `contentInputs` are considered
   files?: string[]; // Glob patterns to include files and directories (default: all)
   ignores?: string[]; // Glob patterns to exclude files and directories (default: none)
-  extraInputs?: Input[]; // Additional inputs: content, JSON
+  contentInputs?: Input[]; // Additional inputs: content, JSON
   hashAlgorithm?: string; // Hash algorithm (default: sha1)
 }): Promise<Fingerprint>;
 ```
@@ -61,10 +61,10 @@ interface Fingerprint {
 
 ```ts
 function calculateFingerprintSync(options?: {
-  basePath: string; // Path to directory that the config applies to, if not provided, only `extraInputs` are considered
+  basePath: string; // Path to directory that the config applies to, if not provided, only `contentInputs` are considered
   include?: string[]; // Glob patterns to include files and directories (default: all)
   exclude?: string[]; // Glob patterns to exclude files and directories (default: none)
-  extraInputs?: Input[]; // Additional inputs: content, JSON
+  contentInputs?: Input[]; // Additional inputs: content, JSON
   hashAlgorithm?: string; // Hash algorithm (default: sha1)
 }): Fingerprint;
 ```
@@ -118,7 +118,7 @@ const { hash } = await calculateFingerprint({
 
 ```typescript
 const { hash } = await calculateFingerprint({
-  extraInputs: [
+  contentInputs: [
     { key: "some-config", content: "debug=true" }, // text input
     { key: "so-metadata", json: { version: "1.0", env: "prod" } }, // JSON data: objects, arrays, primitives
     { key: "much-envs", envs: ["BUILD_ENVIROMENT", "FEATURE_FLAG"] }, // env variables

--- a/README.md
+++ b/README.md
@@ -2,26 +2,28 @@
 
 Generate unique fingerprint hashes from filesystem state and other inputs (text, JSON, envs).
 
-## What's This?
+## What is FS Fingerprint?
 
 A fast Node.js library to generate unique fingerprints based on:
 
-- files & directories in your project
-- other inputs: text content, JSON data, environment variables
+- Files & directories in your project
+- Other inputs: text content, JSON data, environment variables
 
 Perfect for building intelligent caching solutions that automatically invalidate when your code or data changes. ⚡
 
 ## Features
 
-- Fast change detection (we have benchmarks!)
+- Fast change detection (with benchmarks)
 - Highly customizable: include/exclude glob patterns, additional inputs, hashing algorithms
-- Simple TypeScript API, both sync and async versions
+- Simple TypeScript API, both sync and async
 - Supports `.gitignore` files
 
 ## Quick Start
 
-1. Install: `npm install fs-fingerprint` (or `yarn/pnpm/bun add fs-fingerprint`)
-2. Code:
+1. **Install:**  
+   `npm install fs-fingerprint`  
+   (or `yarn/pnpm/bun add fs-fingerprint`)
+2. **Usage:**
 
 ```ts
 import { calculateFingerprint } from "fs-fingerprint";
@@ -38,27 +40,24 @@ const { hash } = await calculateFingerprint("/project/path", {
 
 ```ts
 async function calculateFingerprint(
-  basePath: string; // Base path to relsolve "files" and "ignores" patterns against
+  basePath: string, // Base path to resolve "files" and "ignores" patterns
   options?: {
-    files?: string[]; // Glob patterns to include files and directories (default: include all)
-    ignores?: string[]; // Glob patterns to exclude files and directories (default: ignore none)
+    files?: string[]; // Glob patterns to include (default: all)
+    ignores?: string[]; // Glob patterns to exclude (default: none)
     extraInputs?: InputRecord; // Additional inputs: text, JSON, envs, etc.
     hashAlgorithm?: string; // Hash algorithm (default: "sha1")
-    concurrency?: number; // Number of concurrent file reads (default: 16)
-  }
+    concurrency?: number; // Concurrent file reads (default: 16)
+  },
 ): Promise<Fingerprint>;
 ```
 
-Generates a fingerprint hash for filesystem state.
+Generates a fingerprint hash for the filesystem state.
 
-#### Return value
+#### Return Value
 
 ```typescript
 interface Fingerprint {
-  // Overall project fingerprint hash:
-  hash: string;
-
-  // Fingerprint manifest, what's included in the fingerprint:
+  hash: string; // Overall project fingerprint hash
   files: FileHash[]; // File hashes included in the fingerprint
   content: ContentHash[]; // Content hashes included in the fingerprint
 }
@@ -68,39 +67,40 @@ interface Fingerprint {
 
 ```ts
 function calculateFingerprintSync(
-  basePath: string; // Base path to relsolve "files" and "ignores" patterns against
+  basePath: string, // Base path to resolve "files" and "ignores" patterns
   options?: {
-    files?: string[]; // Glob patterns to include files and directories (default: include all)
-    ignores?: string[]; // Glob patterns to exclude files and directories (default: ignore none)
+    files?: string[]; // Glob patterns to include (default: all)
+    ignores?: string[]; // Glob patterns to exclude (default: none)
     extraInputs?: InputRecord; // Additional inputs: text, JSON, envs, etc.
     hashAlgorithm?: string; // Hash algorithm (default: "sha1")
-  }
+  },
 ): Fingerprint;
 ```
 
 Sync version of `calculateFingerprint`:
 
-- generates the same hash value without awaiting
-- but will be slower due to blocking filesystem reads
+- Generates the same hash value without `await`
+- May be slower due to blocking filesystem reads
 
 ### `getGitIgnoredPaths`
 
 ```ts
 function getGitIgnoredPaths(
-  basePath: string; // Base path to look for git ignored paths
-  options: {
-    entireRepo?: boolean; // If passed basePath is not the git root, search for ignored paths in the whole git repository (default: false)
-  }
+  basePath: string, // Base path to look for git ignored paths
+  options?: {
+    entireRepo?: boolean; // Search for ignored paths in the whole repo (default: false)
+  },
 ): string[];
 ```
 
-Helper function to get list of paths ignored by Git from `.gitignore` and other Git settings. This function invokes `git ls-files` command, so it requires Git to be installed and available in PATH.
+Helper to get paths ignored by Git from `.gitignore` and other Git settings.  
+This function invokes `git ls-files`, so Git must be installed and available in PATH.
 
-**Note**: this function might throw in case of errors (e.g. not a git repository). Use try/catch to handle errors.
+**Note:** This function may throw errors (e.g., not a git repository). Use `try/catch` to handle errors.
 
 #### Options
 
-- `entireRepo`: If passed basePath is not the git root, use this option to search for ignored paths in the whole git repository (default: false). Always returns paths relative to the provided `basePath`.
+- `entireRepo`: If `basePath` is not the git root, set this to search the entire repository. Always returns paths relative to `basePath`.
 
 ## Examples
 
@@ -126,10 +126,10 @@ const { hash } = await calculateFingerprint("/project/path", {
 const { hash } = await calculateFingerprint("/project/path", {
   // ...
   content: {
-    "app-config": textContent("debug=true"), // text content
-    "app-metadata": jsonContent({ version: "1.0", env: "prod" }), // JSON data: objects, arrays, primitives
-    "app-envs": envContent(["BUILD_ENVIRONMENT", "FEATURE_FLAG"]), // env variables
-    "signing-key": envContent(["API_KEY"], { secret: true }), // secret env input, do not include value in fingerprint details
+    "app-config": textContent("debug=true"), // Text content
+    "app-metadata": jsonContent({ version: "1.0", env: "prod" }), // JSON data
+    "app-envs": envContent(["BUILD_ENVIRONMENT", "FEATURE_FLAG"]), // Env variables
+    "signing-key": envContent(["API_KEY"], { secret: true }), // Secret env input (value not included in details)
   },
 });
 ```
@@ -162,10 +162,10 @@ const { hash } = calculateFingerprintSync("/project/path", { ...options });
 ## Design Considerations
 
 1. **Flat manifest:**  
-   Final hash is computed from list of all files and their hashes, sorted by their relative paths. This means that renaming or moving a file will change the final fingerprint, even if the file content remains unchanged.
+   The final hash is computed from a list of all files and their hashes, sorted by relative path. Renaming or moving a file changes the fingerprint, even if content is unchanged.
 
 2. **File Hashing:**  
-   Individual file’s hash is based only on its content, but not from the file’s own name or path. The final hash takes both file paths and their content hashes into account.
+   Each file’s hash is based only on its content (not name or path). The final hash includes both file paths and their content hashes.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const { hash } = await calculateFingerprint(rootPath, {
 
 ```ts
 async function calculateFingerprint(
-  basePath: string, // Root directory path to scan
+  basePath: string, // Path to directory that the config applies to
   options?: {
     files?: string[]; // Glob patterns to include files and directories (default: all)
     ignores?: string[]; // Glob patterns to exclude files and directories (default: none)
@@ -62,7 +62,7 @@ interface Fingerprint {
 
 ```ts
 function calculateFingerprintSync(
-  basePath: string, // Root directory path to scan
+  basePath: string, // Path to directory that the config applies to
   options?: {
     include?: string[]; // Glob patterns to include files and directories (default: all)
     exclude?: string[]; // Glob patterns to exclude files and directories (default: none)
@@ -81,7 +81,7 @@ Sync version of `calculateFingerprint`:
 
 ```ts
 function getGitIgnoredPaths(
-  path: string,
+  basePath: string,
   options: {
     entireRepo?: boolean;
   },

--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ const { hash } = await calculateFingerprint("path/to/project", {
 
 ```typescript
 const { hash } = await calculateFingerprint("path/to/project", {
-  contentInputs: [
-    { key: "some-config", content: "debug=true" }, // text input
-    { key: "so-metadata", json: { version: "1.0", env: "prod" } }, // JSON data: objects, arrays, primitives
-    { key: "much-envs", envs: ["BUILD_ENVIRONMENT", "FEATURE_FLAG"] }, // env variables
-    { key: "api-key", envs: ["API_KEY"], secret: true }, // secret env input, do not include value in fingerprint details
-  ],
+  contentInputs: {
+    someConfig: textContent("debug=true"), // text content
+    soMetadata: jsonContent({ version: "1.0", env: "prod" }), // JSON data: objects, arrays, primitives
+    muchEnvs: envContent(["BUILD_ENVIRONMENT", "FEATURE_FLAG"]), // env variables
+    apiKey: envContent(["API_KEY"], { secret: true }), // secret env input, do not include value in fingerprint details
+  },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ async function calculateFingerprint(
   options?: {
     files?: string[]; // Glob patterns to include (default: all)
     ignores?: string[]; // Glob patterns to exclude (default: none)
-    extraInputs?: InputRecord; // Additional inputs: text, JSON, envs, etc.
+    contentInputs?: ContentInput[]; // Additional inputs: text, JSON, envs, etc.
     hashAlgorithm?: string; // Hash algorithm (default: "sha1")
     concurrency?: number; // Concurrent file reads (default: 16)
   },
@@ -71,7 +71,7 @@ function calculateFingerprintSync(
   options?: {
     files?: string[]; // Glob patterns to include (default: all)
     ignores?: string[]; // Glob patterns to exclude (default: none)
-    extraInputs?: InputRecord; // Additional inputs: text, JSON, envs, etc.
+    contentInputs?: ContentInput[]; // Additional inputs: text, JSON, envs, etc.
     hashAlgorithm?: string; // Hash algorithm (default: "sha1")
   },
 ): Fingerprint;
@@ -124,13 +124,12 @@ const { hash } = await calculateFingerprint("/project/path", {
 
 ```typescript
 const { hash } = await calculateFingerprint("/project/path", {
-  // ...
-  content: {
-    "app-config": textContent("debug=true"), // Text content
-    "app-metadata": jsonContent({ version: "1.0", env: "prod" }), // JSON data
-    "app-envs": envContent(["BUILD_ENVIRONMENT", "FEATURE_FLAG"]), // Env variables
-    "signing-key": envContent(["API_KEY"], { secret: true }), // Secret env input (value not included in details)
-  },
+  contentInputs: [
+    textContent("app-config", "debug=true"), // Text content
+    jsonContent("app-metadata", { version: "1.0", env: "prod" }), // JSON data
+    envContent("app-envs", ["BUILD_ENVIRONMENT", "FEATURE_FLAG"]), // Env variables
+    envContent("signing-key", ["API_KEY"], { secret: true }), // Secret env input (value not included in details)
+  ],
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ const { hash } = await calculateFingerprint("./src", {
   extraInputs: [
     { key: "some-config", content: "debug=true" }, // text input
     { key: "so-metadata", json: { version: "1.0", env: "prod" } }, // JSON data: objects, arrays, primitives
-    { key: "much-envs", env: ["BUILD_ENVIROMENT", "FEATURE_FLAG"] }, // env variables
-    { key: "api-key", env: ["API_KEY"], secret: true }, // secret env input, do not include value in fingerprint details
+    { key: "much-envs", envs: ["BUILD_ENVIROMENT", "FEATURE_FLAG"] }, // env variables
+    { key: "api-key", envs: ["API_KEY"], secret: true }, // secret env input, do not include value in fingerprint details
   ],
 });
 ```

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ Perfect for building intelligent caching solutions that automatically invalidate
 ```ts
 import { calculateFingerprint } from "fs-fingerprint";
 
-const { hash } = await calculateFingerprint({
-  basePath: "./project",
+const { hash } = await calculateFingerprint("path/to/project", {
   files: ["ios/", "package.json"],
   ignores: ["build/"],
 });
@@ -34,13 +33,15 @@ const { hash } = await calculateFingerprint({
 ### `calculateFingerprint`
 
 ```ts
-async function calculateFingerprint(options?: {
+async function calculateFingerprint(
   basePath: string; // Path to directory that the config applies to, if not provided, only `contentInputs` are considered
-  files?: string[]; // Glob patterns to include files and directories (default: all)
-  ignores?: string[]; // Glob patterns to exclude files and directories (default: none)
-  contentInputs?: Input[]; // Additional inputs: content, JSON
-  hashAlgorithm?: string; // Hash algorithm (default: sha1)
-}): Promise<Fingerprint>;
+  options?: {
+    files?: string[]; // Glob patterns to include files and directories (default: all)
+    ignores?: string[]; // Glob patterns to exclude files and directories (default: none)
+    contentInputs?: Input[]; // Additional inputs: content, JSON
+    hashAlgorithm?: string; // Hash algorithm (default: sha1)
+  }
+): Promise<Fingerprint>;
 ```
 
 Generates a fingerprint hash for filesystem state.
@@ -49,7 +50,7 @@ Generates a fingerprint hash for filesystem state.
 
 ```typescript
 interface Fingerprint {
-  hash: string; // Hash value representing the overall fingerprint
+  hash: string; // Overall project hash
 
   // Fingerprint manifest:
   files: FileHash[]; // File hashes included in the fingerprint
@@ -60,13 +61,15 @@ interface Fingerprint {
 ### `calculateFingerprintSync`
 
 ```ts
-function calculateFingerprintSync(options?: {
+function calculateFingerprintSync(
   basePath: string; // Path to directory that the config applies to, if not provided, only `contentInputs` are considered
-  include?: string[]; // Glob patterns to include files and directories (default: all)
-  exclude?: string[]; // Glob patterns to exclude files and directories (default: none)
-  contentInputs?: Input[]; // Additional inputs: content, JSON
-  hashAlgorithm?: string; // Hash algorithm (default: sha1)
-}): Fingerprint;
+  options?: {
+    files?: string[]; // Glob patterns to include files and directories (default: all)
+    ignores?: string[]; // Glob patterns to exclude files and directories (default: none)
+    contentInputs?: Input[]; // Additional inputs: content, JSON
+    hashAlgorithm?: string; // Hash algorithm (default: sha1)
+  }
+): Fingerprint;
 ```
 
 Sync version of `calculateFingerprint`:
@@ -77,10 +80,12 @@ Sync version of `calculateFingerprint`:
 ### `getGitIgnoredPaths`
 
 ```ts
-function getGitIgnoredPaths(options: {
+function getGitIgnoredPaths(
   basePath: string; // Path where to look for git ignores
-  entireRepo?: boolean; // Whether to search the rest of the  git repository (default: false)
-}): string[];
+  options: {
+    entireRepo?: boolean; // Whether to search the rest of the  git repository (default: false)
+  }
+): string[];
 ```
 
 Helper function to get list of paths ignored by Git from `.gitignore` and other Git settings. This function invokes `git ls-files` command, so it requires Git to be installed and available in PATH.
@@ -100,15 +105,14 @@ Helper function to get list of paths ignored by Git from `.gitignore` and other 
 **Basic usage:**
 
 ```typescript
-const { hash } = await calculateFingerprint({ basePath: "./src" });
+const { hash } = await calculateFingerprint("path/to/project");
 console.log(hash); // "abc123..."
 ```
 
 **Using include/exclude patterns:**
 
 ```typescript
-const { hash } = await calculateFingerprint({
-  basePath: "./project"
+const { hash } = await calculateFingerprint("path/to/project", {
   files: ["src/", "package.json"],
   ignores: ["**/*.test.ts", "dist"],
 });
@@ -117,7 +121,7 @@ const { hash } = await calculateFingerprint({
 **Using content inputs:**
 
 ```typescript
-const { hash } = await calculateFingerprint({
+const { hash } = await calculateFingerprint("path/to/project", {
   contentInputs: [
     { key: "some-config", content: "debug=true" }, // text input
     { key: "so-metadata", json: { version: "1.0", env: "prod" } }, // JSON data: objects, arrays, primitives
@@ -131,10 +135,9 @@ const { hash } = await calculateFingerprint({
 
 ```typescript
 // Get list of git-ignored paths
-const gitIgnoredPaths = getGitIgnoredPaths({ basePath: "./src" });
+const gitIgnoredPaths = getGitIgnoredPaths("path/to/project");
 
-const { hash } = await calculateFingerprint({
-  basePath: "./src",
+const { hash } = await calculateFingerprint("path/to/project", {
   ignores: [...gitIgnoredPaths, "other/excludes/**"],
 });
 ```
@@ -142,8 +145,7 @@ const { hash } = await calculateFingerprint({
 **Custom hash algorithm:**
 
 ```typescript
-const { hash } = await calculateFingerprint({
-  basePath: "./src",
+const { hash } = await calculateFingerprint("path/to/project", {
   hashAlgorithm: "sha512",
 });
 ```
@@ -151,7 +153,7 @@ const { hash } = await calculateFingerprint({
 **Synchronous call (slower):**
 
 ```typescript
-const { hash } = calculateFingerprintSync({ ...options });
+const { hash } = calculateFingerprintSync("path/to/project", { ...options });
 ```
 
 ## Design Considerations

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Perfect for building intelligent caching solutions that automatically invalidate
 ```ts
 import { calculateFingerprint } from "fs-fingerprint";
 
-const { hash } = await calculateFingerprint("path/to/project", {
+const { hash } = await calculateFingerprint("/project/path", {
   files: ["ios/", "package.json"],
   ignores: ["build/"],
 });
@@ -105,14 +105,14 @@ Helper function to get list of paths ignored by Git from `.gitignore` and other 
 **Basic usage:**
 
 ```typescript
-const { hash } = await calculateFingerprint("path/to/project");
+const { hash } = await calculateFingerprint("/project/path");
 console.log(hash); // "abc123..."
 ```
 
 **Using include/exclude patterns:**
 
 ```typescript
-const { hash } = await calculateFingerprint("path/to/project", {
+const { hash } = await calculateFingerprint("/project/path", {
   files: ["src/", "package.json"],
   ignores: ["**/*.test.ts", "dist"],
 });
@@ -121,7 +121,7 @@ const { hash } = await calculateFingerprint("path/to/project", {
 **Using content inputs:**
 
 ```typescript
-const { hash } = await calculateFingerprint("path/to/project", {
+const { hash } = await calculateFingerprint("/project/path", {
   contentInputs: {
     someConfig: textContent("debug=true"), // text content
     soMetadata: jsonContent({ version: "1.0", env: "prod" }), // JSON data: objects, arrays, primitives
@@ -135,9 +135,9 @@ const { hash } = await calculateFingerprint("path/to/project", {
 
 ```typescript
 // Get list of git-ignored paths
-const gitIgnoredPaths = getGitIgnoredPaths("path/to/project");
+const gitIgnoredPaths = getGitIgnoredPaths("/project/path");
 
-const { hash } = await calculateFingerprint("path/to/project", {
+const { hash } = await calculateFingerprint("/project/path", {
   ignores: [...gitIgnoredPaths, "other/excludes/**"],
 });
 ```
@@ -145,7 +145,7 @@ const { hash } = await calculateFingerprint("path/to/project", {
 **Custom hash algorithm:**
 
 ```typescript
-const { hash } = await calculateFingerprint("path/to/project", {
+const { hash } = await calculateFingerprint("/project/path", {
   hashAlgorithm: "sha512",
 });
 ```
@@ -153,7 +153,7 @@ const { hash } = await calculateFingerprint("path/to/project", {
 **Synchronous call (slower):**
 
 ```typescript
-const { hash } = calculateFingerprintSync("path/to/project", { ...options });
+const { hash } = calculateFingerprintSync("/project/path", { ...options });
 ```
 
 ## Design Considerations

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ interface Fingerprint {
 
 ```ts
 function calculateFingerprintSync(
-  basePath: string; // Path to directory that the config applies to, if not provided, only `contentInputs` are considered
+  basePath: string; // Base path to relsolve "files" and "ignores" patterns against
   options?: {
     files?: string[]; // Glob patterns to include files and directories (default: all)
     ignores?: string[]; // Glob patterns to exclude files and directories (default: none)
@@ -125,7 +125,7 @@ const { hash } = await calculateFingerprint("path/to/project", {
   contentInputs: [
     { key: "some-config", content: "debug=true" }, // text input
     { key: "so-metadata", json: { version: "1.0", env: "prod" } }, // JSON data: objects, arrays, primitives
-    { key: "much-envs", envs: ["BUILD_ENVIROMENT", "FEATURE_FLAG"] }, // env variables
+    { key: "much-envs", envs: ["BUILD_ENVIRONMENT", "FEATURE_FLAG"] }, // env variables
     { key: "api-key", envs: ["API_KEY"], secret: true }, // secret env input, do not include value in fingerprint details
   ],
 });

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ async function calculateFingerprint(
   options?: {
     files?: string[]; // Glob patterns to include files and directories (default: include all)
     ignores?: string[]; // Glob patterns to exclude files and directories (default: ignore none)
-    content?: Input[]; // Additional inputs: text, JSON, envs, etc.
+    extraInputs?: InputRecord; // Additional inputs: text, JSON, envs, etc.
     hashAlgorithm?: string; // Hash algorithm (default: "sha1")
     concurrency?: number; // Number of concurrent file reads (default: 16)
   }
@@ -72,7 +72,7 @@ function calculateFingerprintSync(
   options?: {
     files?: string[]; // Glob patterns to include files and directories (default: include all)
     ignores?: string[]; // Glob patterns to exclude files and directories (default: ignore none)
-    content?: Input[]; // Additional inputs: text, JSON, envs, etc.
+    extraInputs?: InputRecord; // Additional inputs: text, JSON, envs, etc.
     hashAlgorithm?: string; // Hash algorithm (default: "sha1")
   }
 ): Fingerprint;
@@ -124,6 +124,7 @@ const { hash } = await calculateFingerprint("/project/path", {
 
 ```typescript
 const { hash } = await calculateFingerprint("/project/path", {
+  // ...
   content: {
     "app-config": textContent("debug=true"), // text content
     "app-metadata": jsonContent({ version: "1.0", env: "prod" }), // JSON data: objects, arrays, primitives

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Perfect for building intelligent caching solutions that automatically invalidate
 import { calculateFingerprint } from "fs-fingerprint";
 
 const { hash } = await calculateFingerprint(rootPath, {
-  include: ["ios/", "package.json"],
-  exclude: ["build/"],
+  files: ["ios/", "package.json"],
+  ignores: ["build/"],
 });
 ```
 
@@ -34,10 +34,10 @@ const { hash } = await calculateFingerprint(rootPath, {
 
 ```ts
 async function calculateFingerprint(
-  rootDir: string, // Root directory path to scan
+  basePath: string, // Root directory path to scan
   options?: {
-    include?: string[]; // Glob patterns to include files and directories (default: all)
-    exclude?: string[]; // Glob patterns to exclude files and directories (default: none)
+    files?: string[]; // Glob patterns to include files and directories (default: all)
+    ignores?: string[]; // Glob patterns to exclude files and directories (default: none)
     extraInputs?: Input[]; // Additional inputs: content, JSON
     hashAlgorithm?: string; // Hash algorithm (default: sha1)
   },
@@ -62,7 +62,7 @@ interface Fingerprint {
 
 ```ts
 function calculateFingerprintSync(
-  rootDir: string, // Root directory path to scan
+  basePath: string, // Root directory path to scan
   options?: {
     include?: string[]; // Glob patterns to include files and directories (default: all)
     exclude?: string[]; // Glob patterns to exclude files and directories (default: none)
@@ -113,8 +113,8 @@ console.log(hash); // "abc123..."
 
 ```typescript
 const { hash } = await calculateFingerprint("./project", {
-  include: ["src/", "package.json"],
-  exclude: ["**/*.test.ts", "dist"],
+  files: ["src/", "package.json"],
+  ignores: ["**/*.test.ts", "dist"],
 });
 ```
 
@@ -138,7 +138,7 @@ const { hash } = await calculateFingerprint("./src", {
 const gitIgnoredPaths = getGitIgnoredPaths("./src");
 
 const { hash } = await calculateFingerprint("./src", {
-  exclude: [...gitIgnoredPaths, "other/excludes/**"],
+  ignores: [...gitIgnoredPaths, "other/excludes/**"],
 });
 ```
 

--- a/benchmarks/fingerprint.bench.ts
+++ b/benchmarks/fingerprint.bench.ts
@@ -67,8 +67,8 @@ async function runBenchmarks(): Promise<void> {
 
   // React Native benchmarks
   const reactNativeOptions: FingerprintOptions = {
-    include: ["packages", "package.json", "README.md"],
-    exclude: ["**/node_modules/**", "**/.git/**"],
+    files: ["packages", "package.json", "README.md"],
+    ignores: ["**/node_modules/**", "**/.git/**"],
   };
 
   const reactNativePath = repoPaths.get("react-native");
@@ -97,11 +97,11 @@ async function runBenchmarks(): Promise<void> {
   // Expensify benchmarks
   const expensifyPath = repoPaths.get("expensify");
   const iosOptions: FingerprintOptions = {
-    include: ["ios", "package.json"],
+    files: ["ios", "package.json"],
   };
 
   const androidOptions: FingerprintOptions = {
-    include: ["android", "package.json"],
+    files: ["android", "package.json"],
   };
 
   if (expensifyPath) {

--- a/benchmarks/fingerprint.bench.ts
+++ b/benchmarks/fingerprint.bench.ts
@@ -36,10 +36,10 @@ async function runBenchmarks(): Promise<void> {
   const lodashPath = repoPaths.get("lodash");
   if (lodashPath) {
     bench.add("lodash-sync", () => {
-      calculateFingerprintSync(lodashPath);
+      calculateFingerprintSync({ basePath: lodashPath });
     });
     bench.add("lodash", async () => {
-      await calculateFingerprint(lodashPath);
+      await calculateFingerprint({ basePath: lodashPath });
     });
   }
 
@@ -47,10 +47,10 @@ async function runBenchmarks(): Promise<void> {
   const expressPath = repoPaths.get("express");
   if (expressPath) {
     bench.add("express-sync", () => {
-      calculateFingerprintSync(expressPath);
+      calculateFingerprintSync({ basePath: expressPath });
     });
     bench.add("express", async () => {
-      await calculateFingerprint(expressPath);
+      await calculateFingerprint({ basePath: expressPath });
     });
   }
 
@@ -58,36 +58,37 @@ async function runBenchmarks(): Promise<void> {
   const reactPath = repoPaths.get("react");
   if (reactPath) {
     bench.add("react-sync", () => {
-      calculateFingerprintSync(reactPath);
+      calculateFingerprintSync({ basePath: reactPath });
     });
     bench.add("react", async () => {
-      await calculateFingerprint(reactPath);
+      await calculateFingerprint({ basePath: reactPath });
     });
   }
 
   // React Native benchmarks
-  const reactNativeOptions: FingerprintOptions = {
-    files: ["packages", "package.json", "README.md"],
-    ignores: ["**/node_modules/**", "**/.git/**"],
-  };
-
   const reactNativePath = repoPaths.get("react-native");
   if (reactNativePath) {
+    const reactNativeOptions: FingerprintOptions = {
+      basePath: reactNativePath,
+      files: ["packages", "package.json", "README.md"],
+      ignores: ["**/node_modules/**", "**/.git/**"],
+    };
+
     bench.add("react-native-sync", () => {
-      calculateFingerprintSync(reactNativePath, reactNativeOptions);
+      calculateFingerprintSync(reactNativeOptions);
     });
     bench.add("react-native", async () => {
-      await calculateFingerprint(reactNativePath, reactNativeOptions);
+      await calculateFingerprint(reactNativeOptions);
     });
 
     bench.add("react-native (null hash)-sync", () => {
-      calculateFingerprintSync(reactNativePath, {
+      calculateFingerprintSync({
         ...reactNativeOptions,
         hashAlgorithm: "null",
       });
     });
     bench.add("react-native (null hash)", async () => {
-      await calculateFingerprint(reactNativePath, {
+      await calculateFingerprint({
         ...reactNativeOptions,
         hashAlgorithm: "null",
       });
@@ -96,26 +97,28 @@ async function runBenchmarks(): Promise<void> {
 
   // Expensify benchmarks
   const expensifyPath = repoPaths.get("expensify");
-  const iosOptions: FingerprintOptions = {
-    files: ["ios", "package.json"],
-  };
-
-  const androidOptions: FingerprintOptions = {
-    files: ["android", "package.json"],
-  };
 
   if (expensifyPath) {
+    const iosOptions: FingerprintOptions = {
+      basePath: expensifyPath,
+      files: ["ios/", "package.json"],
+    };
+
+    const androidOptions: FingerprintOptions = {
+      basePath: expensifyPath,
+      files: ["android/", "package.json"],
+    };
     bench.add("expensify-ios-sync", () => {
-      calculateFingerprintSync(expensifyPath, iosOptions);
+      calculateFingerprintSync(iosOptions);
     });
     bench.add("expensify-ios", async () => {
-      await calculateFingerprint(expensifyPath, iosOptions);
+      await calculateFingerprint(iosOptions);
     });
     bench.add("expensify-android-sync", () => {
-      calculateFingerprintSync(expensifyPath, androidOptions);
+      calculateFingerprintSync(androidOptions);
     });
     bench.add("expensify-android", async () => {
-      await calculateFingerprint(expensifyPath, androidOptions);
+      await calculateFingerprint(androidOptions);
     });
   }
 

--- a/benchmarks/fingerprint.bench.ts
+++ b/benchmarks/fingerprint.bench.ts
@@ -36,10 +36,10 @@ async function runBenchmarks(): Promise<void> {
   const lodashPath = repoPaths.get("lodash");
   if (lodashPath) {
     bench.add("lodash-sync", () => {
-      calculateFingerprintSync({ basePath: lodashPath });
+      calculateFingerprintSync(lodashPath);
     });
     bench.add("lodash", async () => {
-      await calculateFingerprint({ basePath: lodashPath });
+      await calculateFingerprint(lodashPath);
     });
   }
 
@@ -47,10 +47,10 @@ async function runBenchmarks(): Promise<void> {
   const expressPath = repoPaths.get("express");
   if (expressPath) {
     bench.add("express-sync", () => {
-      calculateFingerprintSync({ basePath: expressPath });
+      calculateFingerprintSync(expressPath);
     });
     bench.add("express", async () => {
-      await calculateFingerprint({ basePath: expressPath });
+      await calculateFingerprint(expressPath);
     });
   }
 
@@ -58,37 +58,36 @@ async function runBenchmarks(): Promise<void> {
   const reactPath = repoPaths.get("react");
   if (reactPath) {
     bench.add("react-sync", () => {
-      calculateFingerprintSync({ basePath: reactPath });
+      calculateFingerprintSync(reactPath);
     });
     bench.add("react", async () => {
-      await calculateFingerprint({ basePath: reactPath });
+      await calculateFingerprint(reactPath);
     });
   }
 
   // React Native benchmarks
+  const reactNativeOptions: FingerprintOptions = {
+    files: ["packages", "package.json", "README.md"],
+    ignores: ["**/node_modules/**", "**/.git/**"],
+  };
+
   const reactNativePath = repoPaths.get("react-native");
   if (reactNativePath) {
-    const reactNativeOptions: FingerprintOptions = {
-      basePath: reactNativePath,
-      files: ["packages", "package.json", "README.md"],
-      ignores: ["**/node_modules/**", "**/.git/**"],
-    };
-
     bench.add("react-native-sync", () => {
-      calculateFingerprintSync(reactNativeOptions);
+      calculateFingerprintSync(reactNativePath, reactNativeOptions);
     });
     bench.add("react-native", async () => {
-      await calculateFingerprint(reactNativeOptions);
+      await calculateFingerprint(reactNativePath, reactNativeOptions);
     });
 
     bench.add("react-native (null hash)-sync", () => {
-      calculateFingerprintSync({
+      calculateFingerprintSync(reactNativePath, {
         ...reactNativeOptions,
         hashAlgorithm: "null",
       });
     });
     bench.add("react-native (null hash)", async () => {
-      await calculateFingerprint({
+      await calculateFingerprint(reactNativePath, {
         ...reactNativeOptions,
         hashAlgorithm: "null",
       });
@@ -97,28 +96,26 @@ async function runBenchmarks(): Promise<void> {
 
   // Expensify benchmarks
   const expensifyPath = repoPaths.get("expensify");
+  const iosOptions: FingerprintOptions = {
+    files: ["ios", "package.json"],
+  };
+
+  const androidOptions: FingerprintOptions = {
+    files: ["android", "package.json"],
+  };
 
   if (expensifyPath) {
-    const iosOptions: FingerprintOptions = {
-      basePath: expensifyPath,
-      files: ["ios/", "package.json"],
-    };
-
-    const androidOptions: FingerprintOptions = {
-      basePath: expensifyPath,
-      files: ["android/", "package.json"],
-    };
     bench.add("expensify-ios-sync", () => {
-      calculateFingerprintSync(iosOptions);
+      calculateFingerprintSync(expensifyPath, iosOptions);
     });
     bench.add("expensify-ios", async () => {
-      await calculateFingerprint(iosOptions);
+      await calculateFingerprint(expensifyPath, iosOptions);
     });
     bench.add("expensify-android-sync", () => {
-      calculateFingerprintSync(androidOptions);
+      calculateFingerprintSync(expensifyPath, androidOptions);
     });
     bench.add("expensify-android", async () => {
-      await calculateFingerprint(androidOptions);
+      await calculateFingerprint(expensifyPath, androidOptions);
     });
   }
 

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -12,18 +12,18 @@ import {
 } from "../src/index.js";
 
 const defaultOptions: FingerprintOptions = {
-  include: ["android", "package.json"],
-  exclude: ["node_modules", "dist"],
+  files: ["android", "package.json"],
+  ignores: ["node_modules", "dist"],
 };
 
 const iosOptions: FingerprintOptions = {
-  include: ["ios", "package.json"],
-  exclude: ["node_modules", "dist"],
+  files: ["ios", "package.json"],
+  ignores: ["node_modules", "dist"],
 };
 
 const androidOptions: FingerprintOptions = {
-  include: ["android", "package.json"],
-  exclude: ["node_modules", "dist"],
+  files: ["android", "package.json"],
+  ignores: ["node_modules", "dist"],
 };
 
 const { values, positionals } = parseArgs({
@@ -41,19 +41,19 @@ const projectType = values.ios ? "ios" : values.android ? "android" : "default";
 const options = values.ios ? iosOptions : values.android ? androidOptions : defaultOptions;
 
 async function main() {
-  const rootDir = positionals[0] ?? process.cwd();
-  if (!existsSync(rootDir)) {
-    console.error(`Path does not exist: ${rootDir}`);
+  const basePath = positionals[0] ?? process.cwd();
+  if (!existsSync(basePath)) {
+    console.error(`Path does not exist: ${basePath}`);
     process.exit(1);
   }
 
   console.log("Mode:", isBaseline ? "baseline" : "current");
   console.log("Project type:", projectType);
-  console.log("Path:", rootDir);
+  console.log("Path:", basePath);
   console.log("Options:", options);
 
   const tsGitIgnore0 = performance.now();
-  const gitIgnoredPaths = getGitIgnoredPaths(rootDir);
+  const gitIgnoredPaths = getGitIgnoredPaths(basePath);
   const tsGitIgnore1 = performance.now();
   console.log(
     `Git-Ignored paths (${(tsGitIgnore1 - tsGitIgnore0).toFixed(1)}ms):`,
@@ -61,15 +61,15 @@ async function main() {
   );
   console.log("");
 
-  const outputDir = join(rootDir, ".fingerprint");
+  const outputDir = join(basePath, ".fingerprint");
 
   const tsSync0 = performance.now();
-  const fingerprintSync = calculateFingerprintSync(rootDir, options);
+  const fingerprintSync = calculateFingerprintSync(basePath, options);
   const tsSync1 = performance.now();
   console.log(`Sync Fingerprint: ${(tsSync1 - tsSync0).toFixed(1)}ms`);
 
   const tsAsync0 = performance.now();
-  const fingerprint = await calculateFingerprint(rootDir, options);
+  const fingerprint = await calculateFingerprint(basePath, options);
   const tsAsync1 = performance.now();
   console.log(`Async Fingerprint: ${(tsAsync1 - tsAsync0).toFixed(1)}ms`);
   compareFingerprints(fingerprint, fingerprintSync, "Sync Fingerprint check");

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -11,6 +11,21 @@ import {
   getGitIgnoredPaths,
 } from "../src/index.js";
 
+const defaultOptions: FingerprintOptions = {
+  files: ["android", "package.json"],
+  ignores: ["node_modules", "dist"],
+};
+
+const iosOptions: FingerprintOptions = {
+  files: ["ios", "package.json"],
+  ignores: ["node_modules", "dist"],
+};
+
+const androidOptions: FingerprintOptions = {
+  files: ["android", "package.json"],
+  ignores: ["node_modules", "dist"],
+};
+
 const { values, positionals } = parseArgs({
   options: {
     baseline: { type: "boolean" },
@@ -19,24 +34,6 @@ const { values, positionals } = parseArgs({
   },
   allowPositionals: true,
 });
-
-const defaultOptions: FingerprintOptions = {
-  basePath: positionals[0] ?? process.cwd(),
-  files: ["android", "package.json"],
-  ignores: ["node_modules", "dist"],
-};
-
-const iosOptions: FingerprintOptions = {
-  basePath: positionals[0] ?? process.cwd(),
-  files: ["ios", "package.json"],
-  ignores: ["node_modules", "dist"],
-};
-
-const androidOptions: FingerprintOptions = {
-  basePath: positionals[0] ?? process.cwd(),
-  files: ["android", "package.json"],
-  ignores: ["node_modules", "dist"],
-};
 
 const isBaseline = values.baseline ?? false;
 
@@ -56,7 +53,7 @@ async function main() {
   console.log("Options:", options);
 
   const tsGitIgnore0 = performance.now();
-  const gitIgnoredPaths = getGitIgnoredPaths({ basePath });
+  const gitIgnoredPaths = getGitIgnoredPaths(basePath);
   const tsGitIgnore1 = performance.now();
   console.log(
     `Git-Ignored paths (${(tsGitIgnore1 - tsGitIgnore0).toFixed(1)}ms):`,
@@ -67,12 +64,12 @@ async function main() {
   const outputDir = join(basePath, ".fingerprint");
 
   const tsSync0 = performance.now();
-  const fingerprintSync = calculateFingerprintSync(options);
+  const fingerprintSync = calculateFingerprintSync(basePath, options);
   const tsSync1 = performance.now();
   console.log(`Sync Fingerprint: ${(tsSync1 - tsSync0).toFixed(1)}ms`);
 
   const tsAsync0 = performance.now();
-  const fingerprint = await calculateFingerprint(options);
+  const fingerprint = await calculateFingerprint(basePath, options);
   const tsAsync1 = performance.now();
   console.log(`Async Fingerprint: ${(tsAsync1 - tsAsync0).toFixed(1)}ms`);
   compareFingerprints(fingerprint, fingerprintSync, "Sync Fingerprint check");

--- a/scripts/run.ts
+++ b/scripts/run.ts
@@ -11,21 +11,6 @@ import {
   getGitIgnoredPaths,
 } from "../src/index.js";
 
-const defaultOptions: FingerprintOptions = {
-  files: ["android", "package.json"],
-  ignores: ["node_modules", "dist"],
-};
-
-const iosOptions: FingerprintOptions = {
-  files: ["ios", "package.json"],
-  ignores: ["node_modules", "dist"],
-};
-
-const androidOptions: FingerprintOptions = {
-  files: ["android", "package.json"],
-  ignores: ["node_modules", "dist"],
-};
-
 const { values, positionals } = parseArgs({
   options: {
     baseline: { type: "boolean" },
@@ -34,6 +19,24 @@ const { values, positionals } = parseArgs({
   },
   allowPositionals: true,
 });
+
+const defaultOptions: FingerprintOptions = {
+  basePath: positionals[0] ?? process.cwd(),
+  files: ["android", "package.json"],
+  ignores: ["node_modules", "dist"],
+};
+
+const iosOptions: FingerprintOptions = {
+  basePath: positionals[0] ?? process.cwd(),
+  files: ["ios", "package.json"],
+  ignores: ["node_modules", "dist"],
+};
+
+const androidOptions: FingerprintOptions = {
+  basePath: positionals[0] ?? process.cwd(),
+  files: ["android", "package.json"],
+  ignores: ["node_modules", "dist"],
+};
 
 const isBaseline = values.baseline ?? false;
 
@@ -53,7 +56,7 @@ async function main() {
   console.log("Options:", options);
 
   const tsGitIgnore0 = performance.now();
-  const gitIgnoredPaths = getGitIgnoredPaths(basePath);
+  const gitIgnoredPaths = getGitIgnoredPaths({ basePath });
   const tsGitIgnore1 = performance.now();
   console.log(
     `Git-Ignored paths (${(tsGitIgnore1 - tsGitIgnore0).toFixed(1)}ms):`,
@@ -64,12 +67,12 @@ async function main() {
   const outputDir = join(basePath, ".fingerprint");
 
   const tsSync0 = performance.now();
-  const fingerprintSync = calculateFingerprintSync(basePath, options);
+  const fingerprintSync = calculateFingerprintSync(options);
   const tsSync1 = performance.now();
   console.log(`Sync Fingerprint: ${(tsSync1 - tsSync0).toFixed(1)}ms`);
 
   const tsAsync0 = performance.now();
-  const fingerprint = await calculateFingerprint(basePath, options);
+  const fingerprint = await calculateFingerprint(options);
   const tsAsync1 = performance.now();
   console.log(`Async Fingerprint: ${(tsAsync1 - tsAsync0).toFixed(1)}ms`);
   compareFingerprints(fingerprint, fingerprintSync, "Sync Fingerprint check");

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -373,7 +373,7 @@ describe("calculateFingerprint", () => {
 
     const options: FingerprintOptions = {
       files: ["**/*.txt", "../../pkg/b", "../../root-file.*"],
-      ignores: [...ignoredPaths],
+      ignores: ignoredPaths,
     };
 
     const fingerprint = await calculateFingerprint(packageRootPath, options);

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -28,7 +28,6 @@ describe("calculateFingerprint", () => {
     writePaths(["file-1.txt", "dir-1/file-2.txt", "dir-2/nested/file-3.txt"]);
 
     const fingerprint = await calculateFingerprint(basePath);
-
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: b2ecd14046c04602378fbac3a04a2ec0408f4db0
       Files:
@@ -49,14 +48,13 @@ describe("calculateFingerprint", () => {
 
   test("supports content inputs", async () => {
     const options: FingerprintOptions = {
-      contentInputs: {
+      content: {
         "test-content-1": { content: "Hello, world!" },
         "test-content-2": { content: "Lorem ipsum" },
       },
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);
-
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: d0ea126b88b40478b2683d693b535fc623ed1385
       Files:
@@ -75,7 +73,7 @@ describe("calculateFingerprint", () => {
 
   test("supports json inputs", async () => {
     const options: FingerprintOptions = {
-      contentInputs: {
+      content: {
         "test-json-1": jsonContent({ foo: "bar", baz: 123 }),
         "test-json-2": jsonContent(["Hello", 123, null, { foo: "bar" }, ["nested", "array"]]),
         "test-json-3": jsonContent("Hello, world!"),
@@ -88,7 +86,6 @@ describe("calculateFingerprint", () => {
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);
-
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 94c38b3e91afbd7723b623ef3778364015b2031d
       Files:
@@ -163,7 +160,6 @@ describe("calculateFingerprint", () => {
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);
-
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: c18e6d8402009e2e2213ce0d1f845435703e6411
       Files:
@@ -205,7 +201,6 @@ describe("calculateFingerprint", () => {
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);
-
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 1cb4f6d53cae1ab8068780c4e64cd4db9eabed45
       Files:
@@ -263,7 +258,6 @@ describe("calculateFingerprint", () => {
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);
-
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: (null)
       Files:
@@ -282,7 +276,7 @@ describe("calculateFingerprint", () => {
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
-  test('handles includes outside of basePath (e.g. "..")', async () => {
+  test('handles "files" outside of "basePath" (e.g. "..")', async () => {
     writePaths(PATHS_TXT.map((p) => path.join("pkg/a", p)));
     writePaths(PATHS_TXT.map((p) => path.join("pkg/b", p)));
     writePaths(["root-file.txt"]);
@@ -318,7 +312,7 @@ describe("calculateFingerprint", () => {
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
-  test('handles includes outside of basePath (e.g. "..") with .gitignore', async () => {
+  test('handles "files" outside of "basePath" (e.g. "..") with .gitignore', async () => {
     writePaths(PATHS_TXT.map((p) => path.join("pkg/a", p)));
     writePaths(PATHS_MD.map((p) => path.join("pkg/a", p)));
     writePaths(PATHS_TXT.map((p) => path.join("pkg/b", p)));

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -26,7 +26,7 @@ describe("calculateFingerprint", () => {
   test("supports files and directories", async () => {
     writePaths(["file-1.txt", "dir-1/file-2.txt", "dir-2/nested/file-3.txt"]);
 
-    const fingerprint = await calculateFingerprint(basePath);
+    const fingerprint = await calculateFingerprint({ basePath });
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: b2ecd14046c04602378fbac3a04a2ec0408f4db0
@@ -42,7 +42,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir-1/file-2.txt")).toBeTruthy();
     expect(findFile(fingerprint, "dir-2/nested/file-3.txt")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(basePath);
+    const fingerprintSync = calculateFingerprintSync({ basePath });
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -54,7 +54,7 @@ describe("calculateFingerprint", () => {
       ],
     };
 
-    const fingerprint = await calculateFingerprint(basePath, options);
+    const fingerprint = await calculateFingerprint(options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: d0ea126b88b40478b2683d693b535fc623ed1385
@@ -68,7 +68,7 @@ describe("calculateFingerprint", () => {
     expect(findData(fingerprint, "test-content-1")).toBeTruthy();
     expect(findData(fingerprint, "test-content-2")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(basePath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -86,7 +86,7 @@ describe("calculateFingerprint", () => {
       ],
     };
 
-    const fingerprint = await calculateFingerprint(basePath, options);
+    const fingerprint = await calculateFingerprint(options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 94c38b3e91afbd7723b623ef3778364015b2031d
@@ -112,7 +112,7 @@ describe("calculateFingerprint", () => {
     expect(findData(fingerprint, "test-json-7")).toBeTruthy();
     expect(findData(fingerprint, "test-json-8")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(basePath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -122,18 +122,19 @@ describe("calculateFingerprint", () => {
       extraInputs: [{ key: "test-json-1", unknown: "This will throw" }],
     };
 
-    expect(() => calculateFingerprint(basePath, options)).toThrow(/Unsupported input type/);
-    expect(() => calculateFingerprintSync(basePath, options)).toThrow(/Unsupported input type/);
+    expect(() => calculateFingerprint(options)).toThrow(/Unsupported input type/);
+    expect(() => calculateFingerprintSync(options)).toThrow(/Unsupported input type/);
   });
 
   test("supports file patterns", async () => {
     writePaths(["file-0.txt", "file-1.txt", "dir-1/file-2.txt", "dir-2/nested/file-3.txt"]);
 
     const options: FingerprintOptions = {
+      basePath,
       files: ["file-1.txt", "dir-1/file-2.txt", "dir-2/", "non-existent.txt", "non-existent-dir/"],
     };
 
-    const fingerprint = await calculateFingerprint(basePath, options);
+    const fingerprint = await calculateFingerprint(options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: b2ecd14046c04602378fbac3a04a2ec0408f4db0
       Files:
@@ -152,7 +153,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "non-existent.txt")).toBeNull();
     expect(findFile(fingerprint, "non-existent-dir")).toBeNull();
 
-    const fingerprintSync = calculateFingerprintSync(basePath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -168,10 +169,11 @@ describe("calculateFingerprint", () => {
     ]);
 
     const options: FingerprintOptions = {
+      basePath,
       ignores: ["**/*.md", "dir-1"],
     };
 
-    const fingerprint = await calculateFingerprint(basePath, options);
+    const fingerprint = await calculateFingerprint(options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: c18e6d8402009e2e2213ce0d1f845435703e6411
@@ -192,7 +194,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir-1/file-4.md")).toBeNull();
     expect(findFile(fingerprint, "dir-2/nested/file-6.md")).toBeNull();
 
-    const fingerprintSync = calculateFingerprintSync(basePath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -209,11 +211,12 @@ describe("calculateFingerprint", () => {
     ]);
 
     const options: FingerprintOptions = {
+      basePath,
       files: ["file-1.txt", "dir-1/", "dir-2"],
       ignores: ["**/*.md", "dir-2/nested"],
     };
 
-    const fingerprint = await calculateFingerprint(basePath, options);
+    const fingerprint = await calculateFingerprint(options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 1cb4f6d53cae1ab8068780c4e64cd4db9eabed45
@@ -234,7 +237,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir-2/nested/file-6.md")).toBeNull();
     expect(findFile(fingerprint, "dir-3/file-8.txt")).toBeNull();
 
-    const fingerprintSync = calculateFingerprintSync(basePath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -246,10 +249,11 @@ describe("calculateFingerprint", () => {
     );
 
     const options: FingerprintOptions = {
+      basePath,
       files: ["dir-1/file-link1.txt"],
     };
 
-    const fingerprint = await calculateFingerprint(basePath, options);
+    const fingerprint = await calculateFingerprint(options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 4e8e0ad25176ea41bb7a701b9619a044a27b50da
       Files:
@@ -260,7 +264,7 @@ describe("calculateFingerprint", () => {
 
     expect(findFile(fingerprint, "dir-1/file-link1.txt")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(basePath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -268,10 +272,11 @@ describe("calculateFingerprint", () => {
     writePaths(["file-1.txt", "dir-1/file-2.txt", "dir-2/nested/file-3.txt"]);
 
     const options: FingerprintOptions = {
+      basePath,
       hashAlgorithm: "null",
     };
 
-    const fingerprint = await calculateFingerprint(basePath, options);
+    const fingerprint = await calculateFingerprint(options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: (null)
@@ -287,7 +292,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir-1/file-2.txt")).toBeTruthy();
     expect(findFile(fingerprint, "dir-2/nested/file-3.txt")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(basePath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -297,11 +302,11 @@ describe("calculateFingerprint", () => {
     writePaths(["root-file.txt"]);
 
     const options: FingerprintOptions = {
+      basePath: path.join(basePath, "pkg/a"),
       files: ["**/*.txt", "../../pkg/b/**/*.txt", "../../root-file.txt"],
     };
 
-    const packagePath = path.join(basePath, "pkg/a");
-    const fingerprint = await calculateFingerprint(packagePath, options);
+    const fingerprint = await calculateFingerprint(options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 517f0f053c6726df50bdf41e4d2f2f1f8c58feca
       Files:
@@ -323,7 +328,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "../b/dir/file2.txt")).toBeTruthy();
     expect(findFile(fingerprint, "../b/dir/subdir/file3.txt")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(packagePath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -339,8 +344,8 @@ describe("calculateFingerprint", () => {
       cwd: basePath,
     });
 
-    const packageRootPath = path.join(basePath, "pkg/a");
-    const ignoredPaths = getGitIgnoredPaths(packageRootPath, { entireRepo: true });
+    const packagePath = path.join(basePath, "pkg/a");
+    const ignoredPaths = getGitIgnoredPaths({ basePath: packagePath, entireRepo: true });
     expect(ignoredPaths).toMatchInlineSnapshot(`
       [
         "../../root-file.md",
@@ -354,11 +359,12 @@ describe("calculateFingerprint", () => {
     `);
 
     const options: FingerprintOptions = {
+      basePath: packagePath,
       files: ["**/*.txt", "../../pkg/b", "../../root-file.*"],
       ignores: [...ignoredPaths],
     };
 
-    const fingerprint = await calculateFingerprint(packageRootPath, options);
+    const fingerprint = await calculateFingerprint(options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 517f0f053c6726df50bdf41e4d2f2f1f8c58feca
       Files:
@@ -388,7 +394,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "../b/dir/file2.md")).toBeNull();
     expect(findFile(fingerprint, "../b/dir/subdir/file3.md")).toBeNull();
 
-    const fingerprintSync = calculateFingerprintSync(packageRootPath, options);
+    const fingerprintSync = calculateFingerprintSync(options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 });

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -12,6 +12,7 @@ import {
   type FingerprintOptions,
   getGitIgnoredPaths,
 } from "../index.js";
+import { jsonContent } from "../inputs/content.js";
 
 const PATHS_TXT = ["file1.txt", "dir/file2.txt", "dir/subdir/file3.txt"];
 const PATHS_MD = ["file1.md", "dir/file2.md", "dir/subdir/file3.md"];
@@ -48,10 +49,10 @@ describe("calculateFingerprint", () => {
 
   test("supports content inputs", async () => {
     const options: FingerprintOptions = {
-      contentInputs: [
-        { key: "test-content-1", content: "Hello, world!" },
-        { key: "test-content-2", content: "Lorem ipsum" },
-      ],
+      contentInputs: {
+        "test-content-1": { content: "Hello, world!" },
+        "test-content-2": { content: "Lorem ipsum" },
+      },
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);
@@ -74,16 +75,16 @@ describe("calculateFingerprint", () => {
 
   test("supports json inputs", async () => {
     const options: FingerprintOptions = {
-      contentInputs: [
-        { key: "test-json-1", json: { foo: "bar", baz: 123 } },
-        { key: "test-json-2", json: ["Hello", 123, null, { foo: "bar" }, ["nested", "array"]] },
-        { key: "test-json-3", json: "Hello, world!" },
-        { key: "test-json-4", json: 123 },
-        { key: "test-json-5", json: true },
-        { key: "test-json-6", json: false },
-        { key: "test-json-7", json: null },
-        { key: "test-json-8", json: undefined },
-      ],
+      contentInputs: {
+        "test-json-1": jsonContent({ foo: "bar", baz: 123 }),
+        "test-json-2": jsonContent(["Hello", 123, null, { foo: "bar" }, ["nested", "array"]]),
+        "test-json-3": jsonContent("Hello, world!"),
+        "test-json-4": jsonContent(123),
+        "test-json-5": jsonContent(true),
+        "test-json-6": jsonContent(false),
+        "test-json-7": jsonContent(null),
+        "test-json-8": jsonContent(undefined),
+      },
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);
@@ -114,16 +115,6 @@ describe("calculateFingerprint", () => {
 
     const fingerprintSync = calculateFingerprintSync(basePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
-  });
-
-  test("throws for unsupported input type", async () => {
-    const options: FingerprintOptions = {
-      // @ts-expect-error - This is intentionally invalid input type
-      contentInputs: [{ key: "test-json-1", unknown: "This will throw" }],
-    };
-
-    expect(() => calculateFingerprint(basePath, options)).toThrow(/Unsupported input type/);
-    expect(() => calculateFingerprintSync(basePath, options)).toThrow(/Unsupported input type/);
   });
 
   test("supports file patterns", async () => {

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -48,7 +48,7 @@ describe("calculateFingerprint", () => {
 
   test("supports content inputs", async () => {
     const options: FingerprintOptions = {
-      extraInputs: [
+      contentInputs: [
         { key: "test-content-1", content: "Hello, world!" },
         { key: "test-content-2", content: "Lorem ipsum" },
       ],
@@ -74,7 +74,7 @@ describe("calculateFingerprint", () => {
 
   test("supports json inputs", async () => {
     const options: FingerprintOptions = {
-      extraInputs: [
+      contentInputs: [
         { key: "test-json-1", json: { foo: "bar", baz: 123 } },
         { key: "test-json-2", json: ["Hello", 123, null, { foo: "bar" }, ["nested", "array"]] },
         { key: "test-json-3", json: "Hello, world!" },
@@ -119,7 +119,7 @@ describe("calculateFingerprint", () => {
   test("throws for unsupported input type", async () => {
     const options: FingerprintOptions = {
       // @ts-expect-error - This is intentionally invalid input type
-      extraInputs: [{ key: "test-json-1", unknown: "This will throw" }],
+      contentInputs: [{ key: "test-json-1", unknown: "This will throw" }],
     };
 
     expect(() => calculateFingerprint(options)).toThrow(/Unsupported input type/);

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -48,7 +48,7 @@ describe("calculateFingerprint", () => {
 
   test("supports content inputs", async () => {
     const options: FingerprintOptions = {
-      content: {
+      extraInputs: {
         "test-content-1": { content: "Hello, world!" },
         "test-content-2": { content: "Lorem ipsum" },
       },
@@ -73,7 +73,7 @@ describe("calculateFingerprint", () => {
 
   test("supports json inputs", async () => {
     const options: FingerprintOptions = {
-      content: {
+      extraInputs: {
         "test-json-1": jsonContent({ foo: "bar", baz: 123 }),
         "test-json-2": jsonContent(["Hello", 123, null, { foo: "bar" }, ["nested", "array"]]),
         "test-json-3": jsonContent("Hello, world!"),

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -72,6 +72,9 @@ describe("calculateFingerprint", () => {
   });
 
   test("returns same hash for equal contentInputs", async () => {
+    process.env.TEST_ENV_1 = "value1";
+    process.env.TEST_ENV_2 = "value2";
+
     const contents1 = [
       textContent("content-1", "Hello, world!"),
       jsonContent("json-1", { foo: "bar", baz: 123 }),
@@ -86,11 +89,11 @@ describe("calculateFingerprint", () => {
 
     const fingerprint1 = await calculateFingerprint(basePath, { contentInputs: contents1 });
     expect(formatFingerprint(fingerprint1)).toMatchInlineSnapshot(`
-      "Hash: c507de80346efa79c3eaffa1801af5a59583d3dd
+      "Hash: 1fd8ed3ee973eab60b588ae14eb33cee949cd52b
       Files:
       Content:
       - content-1 - 943a702d06f34599aee1f8da8ef9f7296031d699
-      - env-1 - 94ea284f1c2e92defededc9a4ba430af0612be2b
+      - env-1 - 1c93d4a1173659eeb47f774df05fce7a90c47a56
       - json-1 - 7391dce2d9080f78b92f62bb43b308a2f073b0e5
       "
     `);
@@ -102,6 +105,9 @@ describe("calculateFingerprint", () => {
     expect(fingerprintSync1).toEqual(fingerprint1);
     const fingerprintSync2 = calculateFingerprintSync(basePath, { contentInputs: contents2 });
     expect(fingerprintSync2).toEqual(fingerprint1);
+
+    delete process.env.TEST_ENV_1;
+    delete process.env.TEST_ENV_2;
   });
 
   test("supports json inputs", async () => {

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -48,10 +48,10 @@ describe("calculateFingerprint", () => {
 
   test("supports content inputs", async () => {
     const options: FingerprintOptions = {
-      extraInputs: {
-        "test-content-1": textContent("Hello, world!"),
-        "test-content-2": textContent("Lorem ipsum"),
-      },
+      contentInputs: [
+        textContent("test-content-1", "Hello, world!"),
+        textContent("test-content-2", "Lorem ipsum"),
+      ],
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);
@@ -71,20 +71,20 @@ describe("calculateFingerprint", () => {
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
-  test("returns same hash for equal extraInputs", async () => {
-    const contents1 = {
-      "content-1": textContent("Hello, world!"),
-      "json-1": jsonContent({ foo: "bar", baz: 123 }),
-      "env-1": envContent(["TEST_ENV_1", "TEST_ENV_2"]),
-    };
+  test("returns same hash for equal contentInputs", async () => {
+    const contents1 = [
+      textContent("content-1", "Hello, world!"),
+      jsonContent("json-1", { foo: "bar", baz: 123 }),
+      envContent("env-1", ["TEST_ENV_1", "TEST_ENV_2"]),
+    ];
 
-    const contents2 = {
-      "env-1": envContent(["TEST_ENV_1", "TEST_ENV_2"]),
-      "json-1": jsonContent({ foo: "bar", baz: 123 }),
-      "content-1": textContent("Hello, world!"),
-    };
+    const contents2 = [
+      envContent("env-1", ["TEST_ENV_1", "TEST_ENV_2"]),
+      jsonContent("json-1", { foo: "bar", baz: 123 }),
+      textContent("content-1", "Hello, world!"),
+    ];
 
-    const fingerprint1 = await calculateFingerprint(basePath, { extraInputs: contents1 });
+    const fingerprint1 = await calculateFingerprint(basePath, { contentInputs: contents1 });
     expect(formatFingerprint(fingerprint1)).toMatchInlineSnapshot(`
       "Hash: c507de80346efa79c3eaffa1801af5a59583d3dd
       Files:
@@ -95,27 +95,27 @@ describe("calculateFingerprint", () => {
       "
     `);
 
-    const fingerprint2 = await calculateFingerprint(basePath, { extraInputs: contents2 });
+    const fingerprint2 = await calculateFingerprint(basePath, { contentInputs: contents2 });
     expect(fingerprint1).toEqual(fingerprint2);
 
-    const fingerprintSync1 = calculateFingerprintSync(basePath, { extraInputs: contents1 });
+    const fingerprintSync1 = calculateFingerprintSync(basePath, { contentInputs: contents1 });
     expect(fingerprintSync1).toEqual(fingerprint1);
-    const fingerprintSync2 = calculateFingerprintSync(basePath, { extraInputs: contents2 });
+    const fingerprintSync2 = calculateFingerprintSync(basePath, { contentInputs: contents2 });
     expect(fingerprintSync2).toEqual(fingerprint1);
   });
 
   test("supports json inputs", async () => {
     const options: FingerprintOptions = {
-      extraInputs: {
-        "test-json-1": jsonContent({ foo: "bar", baz: 123 }),
-        "test-json-2": jsonContent(["Hello", 123, null, { foo: "bar" }, ["nested", "array"]]),
-        "test-json-3": jsonContent("Hello, world!"),
-        "test-json-4": jsonContent(123),
-        "test-json-5": jsonContent(true),
-        "test-json-6": jsonContent(false),
-        "test-json-7": jsonContent(null),
-        "test-json-8": jsonContent(undefined),
-      },
+      contentInputs: [
+        jsonContent("test-json-1", { foo: "bar", baz: 123 }),
+        jsonContent("test-json-2", ["Hello", 123, null, { foo: "bar" }, ["nested", "array"]]),
+        jsonContent("test-json-3", "Hello, world!"),
+        jsonContent("test-json-4", 123),
+        jsonContent("test-json-5", true),
+        jsonContent("test-json-6", false),
+        jsonContent("test-json-7", null),
+        jsonContent("test-json-8", undefined),
+      ],
     };
 
     const fingerprint = await calculateFingerprint(basePath, options);

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -26,7 +26,7 @@ describe("calculateFingerprint", () => {
   test("supports files and directories", async () => {
     writePaths(["file-1.txt", "dir-1/file-2.txt", "dir-2/nested/file-3.txt"]);
 
-    const fingerprint = await calculateFingerprint({ basePath });
+    const fingerprint = await calculateFingerprint(basePath);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: b2ecd14046c04602378fbac3a04a2ec0408f4db0
@@ -42,7 +42,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir-1/file-2.txt")).toBeTruthy();
     expect(findFile(fingerprint, "dir-2/nested/file-3.txt")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync({ basePath });
+    const fingerprintSync = calculateFingerprintSync(basePath);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -54,7 +54,7 @@ describe("calculateFingerprint", () => {
       ],
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const fingerprint = await calculateFingerprint(basePath, options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: d0ea126b88b40478b2683d693b535fc623ed1385
@@ -68,7 +68,7 @@ describe("calculateFingerprint", () => {
     expect(findData(fingerprint, "test-content-1")).toBeTruthy();
     expect(findData(fingerprint, "test-content-2")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(basePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -86,7 +86,7 @@ describe("calculateFingerprint", () => {
       ],
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const fingerprint = await calculateFingerprint(basePath, options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 94c38b3e91afbd7723b623ef3778364015b2031d
@@ -112,7 +112,7 @@ describe("calculateFingerprint", () => {
     expect(findData(fingerprint, "test-json-7")).toBeTruthy();
     expect(findData(fingerprint, "test-json-8")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(basePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -122,19 +122,18 @@ describe("calculateFingerprint", () => {
       contentInputs: [{ key: "test-json-1", unknown: "This will throw" }],
     };
 
-    expect(() => calculateFingerprint(options)).toThrow(/Unsupported input type/);
-    expect(() => calculateFingerprintSync(options)).toThrow(/Unsupported input type/);
+    expect(() => calculateFingerprint(basePath, options)).toThrow(/Unsupported input type/);
+    expect(() => calculateFingerprintSync(basePath, options)).toThrow(/Unsupported input type/);
   });
 
   test("supports file patterns", async () => {
     writePaths(["file-0.txt", "file-1.txt", "dir-1/file-2.txt", "dir-2/nested/file-3.txt"]);
 
     const options: FingerprintOptions = {
-      basePath,
       files: ["file-1.txt", "dir-1/file-2.txt", "dir-2/", "non-existent.txt", "non-existent-dir/"],
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const fingerprint = await calculateFingerprint(basePath, options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: b2ecd14046c04602378fbac3a04a2ec0408f4db0
       Files:
@@ -153,7 +152,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "non-existent.txt")).toBeNull();
     expect(findFile(fingerprint, "non-existent-dir")).toBeNull();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(basePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -169,11 +168,10 @@ describe("calculateFingerprint", () => {
     ]);
 
     const options: FingerprintOptions = {
-      basePath,
       ignores: ["**/*.md", "dir-1"],
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const fingerprint = await calculateFingerprint(basePath, options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: c18e6d8402009e2e2213ce0d1f845435703e6411
@@ -194,7 +192,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir-1/file-4.md")).toBeNull();
     expect(findFile(fingerprint, "dir-2/nested/file-6.md")).toBeNull();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(basePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -211,12 +209,11 @@ describe("calculateFingerprint", () => {
     ]);
 
     const options: FingerprintOptions = {
-      basePath,
       files: ["file-1.txt", "dir-1/", "dir-2"],
       ignores: ["**/*.md", "dir-2/nested"],
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const fingerprint = await calculateFingerprint(basePath, options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 1cb4f6d53cae1ab8068780c4e64cd4db9eabed45
@@ -237,7 +234,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir-2/nested/file-6.md")).toBeNull();
     expect(findFile(fingerprint, "dir-3/file-8.txt")).toBeNull();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(basePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -249,11 +246,10 @@ describe("calculateFingerprint", () => {
     );
 
     const options: FingerprintOptions = {
-      basePath,
       files: ["dir-1/file-link1.txt"],
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const fingerprint = await calculateFingerprint(basePath, options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 4e8e0ad25176ea41bb7a701b9619a044a27b50da
       Files:
@@ -264,7 +260,7 @@ describe("calculateFingerprint", () => {
 
     expect(findFile(fingerprint, "dir-1/file-link1.txt")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(basePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -272,11 +268,10 @@ describe("calculateFingerprint", () => {
     writePaths(["file-1.txt", "dir-1/file-2.txt", "dir-2/nested/file-3.txt"]);
 
     const options: FingerprintOptions = {
-      basePath,
       hashAlgorithm: "null",
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const fingerprint = await calculateFingerprint(basePath, options);
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: (null)
@@ -292,7 +287,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir-1/file-2.txt")).toBeTruthy();
     expect(findFile(fingerprint, "dir-2/nested/file-3.txt")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(basePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -302,11 +297,11 @@ describe("calculateFingerprint", () => {
     writePaths(["root-file.txt"]);
 
     const options: FingerprintOptions = {
-      basePath: path.join(basePath, "pkg/a"),
       files: ["**/*.txt", "../../pkg/b/**/*.txt", "../../root-file.txt"],
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const packagePath = path.join(basePath, "pkg/a");
+    const fingerprint = await calculateFingerprint(packagePath, options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 517f0f053c6726df50bdf41e4d2f2f1f8c58feca
       Files:
@@ -328,7 +323,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "../b/dir/file2.txt")).toBeTruthy();
     expect(findFile(fingerprint, "../b/dir/subdir/file3.txt")).toBeTruthy();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(packagePath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
@@ -344,8 +339,8 @@ describe("calculateFingerprint", () => {
       cwd: basePath,
     });
 
-    const packagePath = path.join(basePath, "pkg/a");
-    const ignoredPaths = getGitIgnoredPaths({ basePath: packagePath, entireRepo: true });
+    const packageRootPath = path.join(basePath, "pkg/a");
+    const ignoredPaths = getGitIgnoredPaths(packageRootPath, { entireRepo: true });
     expect(ignoredPaths).toMatchInlineSnapshot(`
       [
         "../../root-file.md",
@@ -359,12 +354,11 @@ describe("calculateFingerprint", () => {
     `);
 
     const options: FingerprintOptions = {
-      basePath: packagePath,
       files: ["**/*.txt", "../../pkg/b", "../../root-file.*"],
       ignores: [...ignoredPaths],
     };
 
-    const fingerprint = await calculateFingerprint(options);
+    const fingerprint = await calculateFingerprint(packageRootPath, options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 517f0f053c6726df50bdf41e4d2f2f1f8c58feca
       Files:
@@ -394,7 +388,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "../b/dir/file2.md")).toBeNull();
     expect(findFile(fingerprint, "../b/dir/subdir/file3.md")).toBeNull();
 
-    const fingerprintSync = calculateFingerprintSync(options);
+    const fingerprintSync = calculateFingerprintSync(packageRootPath, options);
     expect(fingerprintSync).toEqual(fingerprint);
   });
 });

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -26,7 +26,7 @@ describe("getGitIgnoredPaths", () => {
       cwd: basePath,
     });
 
-    const ignoredFiles = getGitIgnoredPaths(basePath);
+    const ignoredFiles = getGitIgnoredPaths({ basePath });
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [
         "dir/file2.md",
@@ -42,7 +42,7 @@ describe("getGitIgnoredPaths", () => {
     expect(ignoredFiles).toContain("dir/subdir/");
     expect(ignoredFiles).not.toContain("file1.txt");
 
-    const ignoredFilesWithOutside = getGitIgnoredPaths(basePath, { entireRepo: true });
+    const ignoredFilesWithOutside = getGitIgnoredPaths({ basePath, entireRepo: true });
     expect(ignoredFilesWithOutside).toEqual(ignoredFiles);
   });
 
@@ -51,7 +51,7 @@ describe("getGitIgnoredPaths", () => {
     writePaths(PATHS_MD);
     writeFile(".gitignore", "*.md\ndir/subdir/");
 
-    expect(() => getGitIgnoredPaths(basePath)).toThrowErrorMatchingInlineSnapshot(`
+    expect(() => getGitIgnoredPaths({ basePath })).toThrowErrorMatchingInlineSnapshot(`
       "Failed to get git ignored files.
 
       Command failed: git ls-files -z --others --ignored --exclude-standard --directory
@@ -59,7 +59,7 @@ describe("getGitIgnoredPaths", () => {
       "
     `);
 
-    expect(() => getGitIgnoredPaths(basePath, { entireRepo: true }))
+    expect(() => getGitIgnoredPaths({ basePath, entireRepo: true }))
       .toThrowErrorMatchingInlineSnapshot(`
       "Failed to get git root path.
 
@@ -79,8 +79,8 @@ describe("getGitIgnoredPaths", () => {
       cwd: basePath,
     });
 
-    const packageDir = path.join(basePath, pkgPath);
-    const ignoredFiles = getGitIgnoredPaths(packageDir);
+    const options = { basePath: path.join(basePath, pkgPath) };
+    const ignoredFiles = getGitIgnoredPaths(options);
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [
         "dir/file2.md",
@@ -93,7 +93,7 @@ describe("getGitIgnoredPaths", () => {
     expect(ignoredFiles).toContain("dir/file2.md");
     expect(ignoredFiles).toContain("dir/subdir/file3.md");
 
-    const ignoredFilesWithOutside = getGitIgnoredPaths(packageDir, { entireRepo: true });
+    const ignoredFilesWithOutside = getGitIgnoredPaths({ ...options, entireRepo: true });
     expect(ignoredFilesWithOutside).toEqual(ignoredFiles);
   });
 
@@ -108,7 +108,7 @@ describe("getGitIgnoredPaths", () => {
     execSync("git init", { cwd: basePath });
 
     const jsPkgPath = path.join(basePath, "pkg/js");
-    const ignoredFiles = getGitIgnoredPaths(jsPkgPath, { entireRepo: true });
+    const ignoredFiles = getGitIgnoredPaths({ basePath: jsPkgPath, entireRepo: true });
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [
         "../../root-file.md",

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import { createRootDir } from "../../test-utils/fs.js";
-import { getGitIgnoredPaths, remapPaths } from "../git.js";
+import { getGitIgnoredPaths, rebasePath } from "../git.js";
 
 const { basePath, prepareRootDir, writePaths, writeFile } = createRootDir("git-test");
 
@@ -127,7 +127,7 @@ describe("getGitIgnoredPaths", () => {
 
 describe("remapPaths", () => {
   test("handles basic cases", () => {
-    expect(remapPaths("file.txt", "/a/b/", "/a/b/c/")).toEqual("../file.txt");
-    expect(remapPaths("file.txt", "/a/", "/a/b/c/")).toEqual("../../file.txt");
+    expect(rebasePath("file.txt", "/a/b/", "/a/b/c/")).toEqual("../file.txt");
+    expect(rebasePath("file.txt", "/a/", "/a/b/c/")).toEqual("../../file.txt");
   });
 });

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -125,7 +125,7 @@ describe("getGitIgnoredPaths", () => {
   });
 });
 
-describe("remapPaths", () => {
+describe("rebasePaths", () => {
   test("handles basic cases", () => {
     expect(rebasePath("file.txt", "/a/b/", "/a/b/c/")).toEqual("../file.txt");
     expect(rebasePath("file.txt", "/a/", "/a/b/c/")).toEqual("../../file.txt");

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -26,7 +26,7 @@ describe("getGitIgnoredPaths", () => {
       cwd: basePath,
     });
 
-    const ignoredFiles = getGitIgnoredPaths({ basePath });
+    const ignoredFiles = getGitIgnoredPaths(basePath);
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [
         "dir/file2.md",
@@ -42,7 +42,7 @@ describe("getGitIgnoredPaths", () => {
     expect(ignoredFiles).toContain("dir/subdir/");
     expect(ignoredFiles).not.toContain("file1.txt");
 
-    const ignoredFilesWithOutside = getGitIgnoredPaths({ basePath, entireRepo: true });
+    const ignoredFilesWithOutside = getGitIgnoredPaths(basePath, { entireRepo: true });
     expect(ignoredFilesWithOutside).toEqual(ignoredFiles);
   });
 
@@ -51,7 +51,7 @@ describe("getGitIgnoredPaths", () => {
     writePaths(PATHS_MD);
     writeFile(".gitignore", "*.md\ndir/subdir/");
 
-    expect(() => getGitIgnoredPaths({ basePath })).toThrowErrorMatchingInlineSnapshot(`
+    expect(() => getGitIgnoredPaths(basePath)).toThrowErrorMatchingInlineSnapshot(`
       "Failed to get git ignored files.
 
       Command failed: git ls-files -z --others --ignored --exclude-standard --directory
@@ -59,7 +59,7 @@ describe("getGitIgnoredPaths", () => {
       "
     `);
 
-    expect(() => getGitIgnoredPaths({ basePath, entireRepo: true }))
+    expect(() => getGitIgnoredPaths(basePath, { entireRepo: true }))
       .toThrowErrorMatchingInlineSnapshot(`
       "Failed to get git root path.
 
@@ -79,8 +79,8 @@ describe("getGitIgnoredPaths", () => {
       cwd: basePath,
     });
 
-    const options = { basePath: path.join(basePath, pkgPath) };
-    const ignoredFiles = getGitIgnoredPaths(options);
+    const packageDir = path.join(basePath, pkgPath);
+    const ignoredFiles = getGitIgnoredPaths(packageDir);
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [
         "dir/file2.md",
@@ -93,7 +93,7 @@ describe("getGitIgnoredPaths", () => {
     expect(ignoredFiles).toContain("dir/file2.md");
     expect(ignoredFiles).toContain("dir/subdir/file3.md");
 
-    const ignoredFilesWithOutside = getGitIgnoredPaths({ ...options, entireRepo: true });
+    const ignoredFilesWithOutside = getGitIgnoredPaths(packageDir, { entireRepo: true });
     expect(ignoredFilesWithOutside).toEqual(ignoredFiles);
   });
 
@@ -108,7 +108,7 @@ describe("getGitIgnoredPaths", () => {
     execSync("git init", { cwd: basePath });
 
     const jsPkgPath = path.join(basePath, "pkg/js");
-    const ignoredFiles = getGitIgnoredPaths({ basePath: jsPkgPath, entireRepo: true });
+    const ignoredFiles = getGitIgnoredPaths(jsPkgPath, { entireRepo: true });
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [
         "../../root-file.md",

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { createRootDir } from "../../test-utils/fs.js";
 import { getGitIgnoredPaths, remapPaths } from "../git.js";
 
-const { rootDir, prepareRootDir, writePaths, writeFile } = createRootDir("git-test");
+const { basePath, prepareRootDir, writePaths, writeFile } = createRootDir("git-test");
 
 beforeEach(() => {
   prepareRootDir();
@@ -23,10 +23,10 @@ describe("getGitIgnoredPaths", () => {
     writeFile("dir/.gitignore", "file2.txt");
 
     execSync("git init", {
-      cwd: rootDir,
+      cwd: basePath,
     });
 
-    const ignoredFiles = getGitIgnoredPaths(rootDir);
+    const ignoredFiles = getGitIgnoredPaths(basePath);
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [
         "dir/file2.md",
@@ -42,7 +42,7 @@ describe("getGitIgnoredPaths", () => {
     expect(ignoredFiles).toContain("dir/subdir/");
     expect(ignoredFiles).not.toContain("file1.txt");
 
-    const ignoredFilesWithOutside = getGitIgnoredPaths(rootDir, { entireRepo: true });
+    const ignoredFilesWithOutside = getGitIgnoredPaths(basePath, { entireRepo: true });
     expect(ignoredFilesWithOutside).toEqual(ignoredFiles);
   });
 
@@ -51,7 +51,7 @@ describe("getGitIgnoredPaths", () => {
     writePaths(PATHS_MD);
     writeFile(".gitignore", "*.md\ndir/subdir/");
 
-    expect(() => getGitIgnoredPaths(rootDir)).toThrowErrorMatchingInlineSnapshot(`
+    expect(() => getGitIgnoredPaths(basePath)).toThrowErrorMatchingInlineSnapshot(`
       "Failed to get git ignored files.
 
       Command failed: git ls-files -z --others --ignored --exclude-standard --directory
@@ -59,7 +59,7 @@ describe("getGitIgnoredPaths", () => {
       "
     `);
 
-    expect(() => getGitIgnoredPaths(rootDir, { entireRepo: true }))
+    expect(() => getGitIgnoredPaths(basePath, { entireRepo: true }))
       .toThrowErrorMatchingInlineSnapshot(`
       "Failed to get git root path.
 
@@ -76,10 +76,10 @@ describe("getGitIgnoredPaths", () => {
 
     writeFile(`.gitignore`, "*.md");
     execSync("git init", {
-      cwd: rootDir,
+      cwd: basePath,
     });
 
-    const packageDir = path.join(rootDir, pkgPath);
+    const packageDir = path.join(basePath, pkgPath);
     const ignoredFiles = getGitIgnoredPaths(packageDir);
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [
@@ -105,9 +105,9 @@ describe("getGitIgnoredPaths", () => {
     writePaths(["pkg/js/package.json"]);
 
     writeFile(`.gitignore`, "*.md");
-    execSync("git init", { cwd: rootDir });
+    execSync("git init", { cwd: basePath });
 
-    const jsPkgPath = path.join(rootDir, "pkg/js");
+    const jsPkgPath = path.join(basePath, "pkg/js");
     const ignoredFiles = getGitIgnoredPaths(jsPkgPath, { entireRepo: true });
     expect(ignoredFiles).toMatchInlineSnapshot(`
       [

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -33,88 +33,86 @@ describe("getFilesToHash", () => {
   test('returns all files when "files" is not specified', async () => {
     writePaths(PATHS_TXT);
 
-    const result = await getInputFiles({ basePath });
+    const result = await getInputFiles(basePath, {});
     expect(result).toEqual(PATHS_TXT);
 
-    const resultSync = getInputFilesSync({ basePath });
+    const resultSync = getInputFilesSync(basePath, {});
     expect(resultSync).toEqual(result);
   });
 
   test('returns empty array when "files" is empty', async () => {
     writePaths(PATHS_TXT);
 
-    const result = await getInputFiles({ basePath, files: [] });
+    const result = await getInputFiles(basePath, { files: [] });
     expect(result).toEqual([]);
 
-    const resultSync = getInputFilesSync({ basePath, files: [] });
+    const resultSync = getInputFilesSync(basePath, { files: [] });
     expect(resultSync).toEqual([]);
   });
 
   test("returns files matching exact filename", async () => {
     writePaths(PATHS_TXT);
 
-    const result1 = await getInputFiles({ basePath, files: ["file1.txt"] });
+    const result1 = await getInputFiles(basePath, { files: ["file1.txt"] });
     expect(result1).toEqual(["file1.txt"]);
-    const resultSync1 = getInputFilesSync({ basePath, files: ["file1.txt"] });
+    const resultSync1 = getInputFilesSync(basePath, { files: ["file1.txt"] });
     expect(resultSync1).toEqual(result1);
 
-    const result2 = await getInputFiles({
-      basePath,
+    const result2 = await getInputFiles(basePath, {
       files: ["file1.txt", "dir/file2.txt"],
     });
     expect(result2).toEqual(["dir/file2.txt", "file1.txt"]);
-    const resultSync2 = getInputFilesSync({
-      basePath,
+    const resultSync2 = getInputFilesSync(basePath, {
       files: ["file1.txt", "dir/file2.txt"],
     });
     expect(resultSync2).toEqual(result2);
 
-    const result3 = await getInputFiles({ basePath, files: ["dir/subdir/file3.txt"] });
+    const result3 = await getInputFiles(basePath, { files: ["dir/subdir/file3.txt"] });
     expect(result3).toEqual(["dir/subdir/file3.txt"]);
-    const resultSync3 = getInputFilesSync({ basePath, files: ["dir/subdir/file3.txt"] });
+    const resultSync3 = getInputFilesSync(basePath, { files: ["dir/subdir/file3.txt"] });
     expect(resultSync3).toEqual(result3);
   });
 
   test("returns files matching glob patterns", async () => {
     writePaths(PATHS_TXT);
 
-    const result1 = await getInputFiles({ basePath, files: ["*.txt"] });
+    const result1 = await getInputFiles(basePath, { files: ["*.txt"] });
     expect(result1).toEqual(["file1.txt"]);
-    const resultSync1 = getInputFilesSync({ basePath, files: ["*.txt"] });
+    const resultSync1 = getInputFilesSync(basePath, { files: ["*.txt"] });
     expect(resultSync1).toEqual(result1);
 
-    const result2 = await getInputFiles({ basePath, files: ["**/*.txt"] });
+    const result2 = await getInputFiles(basePath, { files: ["**/*.txt"] });
     expect(result2).toEqual(PATHS_TXT);
-    const resultSync2 = getInputFilesSync({ basePath, files: ["**/*.txt"] });
+    const resultSync2 = getInputFilesSync(basePath, { files: ["**/*.txt"] });
     expect(resultSync2).toEqual(result2);
   });
 
   test("returns includes directories & their contents", async () => {
     writePaths(PATHS_TXT);
 
-    const result1 = await getInputFiles({ basePath, files: ["dir/**"] });
+    const result1 = await getInputFiles(basePath, { files: ["dir/**"] });
     expect(result1).toEqual(["dir/file2.txt", "dir/subdir/file3.txt"]);
-    const resultSync1 = getInputFilesSync({ basePath, files: ["dir/**"] });
+    const resultSync1 = getInputFilesSync(basePath, { files: ["dir/**"] });
     expect(resultSync1).toEqual(result1);
 
-    const result2 = await getInputFiles({ basePath, files: ["dir"] });
+    const result2 = await getInputFiles(basePath, { files: ["dir"] });
     expect(result2).toEqual(["dir/file2.txt", "dir/subdir/file3.txt"]);
-    const resultSync2 = getInputFilesSync({ basePath, files: ["dir"] });
+    const resultSync2 = getInputFilesSync(basePath, { files: ["dir"] });
     expect(resultSync2).toEqual(result2);
 
-    const result3 = await getInputFiles({ basePath, files: ["dir/"] });
+    const result3 = await getInputFiles(basePath, { files: ["dir/"] });
     expect(result3).toEqual(["dir/file2.txt", "dir/subdir/file3.txt"]);
-    const resultSync3 = getInputFilesSync({ basePath, files: ["dir/"] });
+    const resultSync3 = getInputFilesSync(basePath, { files: ["dir/"] });
     expect(resultSync3).toEqual(result3);
   });
 
   test('returns supports "ignores"', async () => {
     writePaths([...PATHS_TXT, ...PATHS_MD]);
 
-    const result1 = await getInputFiles({ basePath, ignores: ["**/*.md"] });
+    const result1 = await getInputFiles(basePath, { ignores: ["**/*.md"] });
     expect(result1).toEqual(PATHS_TXT);
 
-    const resultSync1 = getInputFilesSync({ basePath, ignores: ["**/*.md"] });
+    const resultSync1 = getInputFilesSync(basePath, { ignores: ["**/*.md"] });
     expect(resultSync1).toEqual(result1);
   });
 });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -5,10 +5,10 @@ import type { ContentHash, FileHash } from "../types.js";
 import { getInputFiles, getInputFilesSync, hashContent, mergeHashes } from "../utils.js";
 
 const baseConfig = {
-  rootDir: "not-used",
+  basePath: "not-used",
 };
 
-const { rootDir, prepareRootDir, writePaths } = createRootDir("utils-test");
+const { basePath, prepareRootDir, writePaths } = createRootDir("utils-test");
 
 beforeEach(() => {
   prepareRootDir();
@@ -30,85 +30,91 @@ const PATHS_TXT = ["file1.txt", "dir/file2.txt", "dir/subdir/file3.txt"].sort();
 const PATHS_MD = ["file1.md", "dir/file2.md", "dir/subdir/file3.md"].sort();
 
 describe("getFilesToHash", () => {
-  test("returns all files when include is not specified", async () => {
+  test('returns all files when "files" is not specified', async () => {
     writePaths(PATHS_TXT);
 
-    const result = await getInputFiles({ rootDir });
+    const result = await getInputFiles({ basePath });
     expect(result).toEqual(PATHS_TXT);
 
-    const resultSync = getInputFilesSync({ rootDir });
+    const resultSync = getInputFilesSync({ basePath });
     expect(resultSync).toEqual(result);
   });
 
-  test("returns empty array when include is empty", async () => {
+  test('returns empty array when "files" is empty', async () => {
     writePaths(PATHS_TXT);
 
-    const result = await getInputFiles({ rootDir, include: [] });
+    const result = await getInputFiles({ basePath, files: [] });
     expect(result).toEqual([]);
 
-    const resultSync = getInputFilesSync({ rootDir, include: [] });
+    const resultSync = getInputFilesSync({ basePath, files: [] });
     expect(resultSync).toEqual([]);
   });
 
   test("returns files matching exact filename", async () => {
     writePaths(PATHS_TXT);
 
-    const result1 = await getInputFiles({ rootDir, include: ["file1.txt"] });
+    const result1 = await getInputFiles({ basePath, files: ["file1.txt"] });
     expect(result1).toEqual(["file1.txt"]);
-    const resultSync1 = getInputFilesSync({ rootDir, include: ["file1.txt"] });
+    const resultSync1 = getInputFilesSync({ basePath, files: ["file1.txt"] });
     expect(resultSync1).toEqual(result1);
 
-    const result2 = await getInputFiles({ rootDir, include: ["file1.txt", "dir/file2.txt"] });
+    const result2 = await getInputFiles({
+      basePath,
+      files: ["file1.txt", "dir/file2.txt"],
+    });
     expect(result2).toEqual(["dir/file2.txt", "file1.txt"]);
-    const resultSync2 = getInputFilesSync({ rootDir, include: ["file1.txt", "dir/file2.txt"] });
+    const resultSync2 = getInputFilesSync({
+      basePath,
+      files: ["file1.txt", "dir/file2.txt"],
+    });
     expect(resultSync2).toEqual(result2);
 
-    const result3 = await getInputFiles({ rootDir, include: ["dir/subdir/file3.txt"] });
+    const result3 = await getInputFiles({ basePath, files: ["dir/subdir/file3.txt"] });
     expect(result3).toEqual(["dir/subdir/file3.txt"]);
-    const resultSync3 = getInputFilesSync({ rootDir, include: ["dir/subdir/file3.txt"] });
+    const resultSync3 = getInputFilesSync({ basePath, files: ["dir/subdir/file3.txt"] });
     expect(resultSync3).toEqual(result3);
   });
 
   test("returns files matching glob patterns", async () => {
     writePaths(PATHS_TXT);
 
-    const result1 = await getInputFiles({ rootDir, include: ["*.txt"] });
+    const result1 = await getInputFiles({ basePath, files: ["*.txt"] });
     expect(result1).toEqual(["file1.txt"]);
-    const resultSync1 = getInputFilesSync({ rootDir, include: ["*.txt"] });
+    const resultSync1 = getInputFilesSync({ basePath, files: ["*.txt"] });
     expect(resultSync1).toEqual(result1);
 
-    const result2 = await getInputFiles({ rootDir, include: ["**/*.txt"] });
+    const result2 = await getInputFiles({ basePath, files: ["**/*.txt"] });
     expect(result2).toEqual(PATHS_TXT);
-    const resultSync2 = getInputFilesSync({ rootDir, include: ["**/*.txt"] });
+    const resultSync2 = getInputFilesSync({ basePath, files: ["**/*.txt"] });
     expect(resultSync2).toEqual(result2);
   });
 
   test("returns includes directories & their contents", async () => {
     writePaths(PATHS_TXT);
 
-    const result1 = await getInputFiles({ rootDir, include: ["dir/**"] });
+    const result1 = await getInputFiles({ basePath, files: ["dir/**"] });
     expect(result1).toEqual(["dir/file2.txt", "dir/subdir/file3.txt"]);
-    const resultSync1 = getInputFilesSync({ rootDir, include: ["dir/**"] });
+    const resultSync1 = getInputFilesSync({ basePath, files: ["dir/**"] });
     expect(resultSync1).toEqual(result1);
 
-    const result2 = await getInputFiles({ rootDir, include: ["dir"] });
+    const result2 = await getInputFiles({ basePath, files: ["dir"] });
     expect(result2).toEqual(["dir/file2.txt", "dir/subdir/file3.txt"]);
-    const resultSync2 = getInputFilesSync({ rootDir, include: ["dir"] });
+    const resultSync2 = getInputFilesSync({ basePath, files: ["dir"] });
     expect(resultSync2).toEqual(result2);
 
-    const result3 = await getInputFiles({ rootDir, include: ["dir/"] });
+    const result3 = await getInputFiles({ basePath, files: ["dir/"] });
     expect(result3).toEqual(["dir/file2.txt", "dir/subdir/file3.txt"]);
-    const resultSync3 = getInputFilesSync({ rootDir, include: ["dir/"] });
+    const resultSync3 = getInputFilesSync({ basePath, files: ["dir/"] });
     expect(resultSync3).toEqual(result3);
   });
 
-  test("returns supports exclude", async () => {
+  test('returns supports "ignores"', async () => {
     writePaths([...PATHS_TXT, ...PATHS_MD]);
 
-    const result1 = await getInputFiles({ rootDir, exclude: ["**/*.md"] });
+    const result1 = await getInputFiles({ basePath, ignores: ["**/*.md"] });
     expect(result1).toEqual(PATHS_TXT);
 
-    const resultSync1 = getInputFilesSync({ rootDir, exclude: ["**/*.md"] });
+    const resultSync1 = getInputFilesSync({ basePath, ignores: ["**/*.md"] });
     expect(resultSync1).toEqual(result1);
   });
 });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { createRootDir } from "../../test-utils/fs.js";
 import type { ContentHash, FileHash } from "../types.js";
-import { getInputFiles, getInputFilesSync, hashContent, mergeHashes } from "../utils.js";
+import { getInputFiles, getInputFilesSync, hashData, mergeHashes } from "../utils.js";
 
 const baseConfig = {
   basePath: "not-used",
@@ -16,12 +16,12 @@ beforeEach(() => {
 
 describe("hashContent", () => {
   test("handles basic case", () => {
-    const hash = hashContent("Hello, world!", baseConfig);
+    const hash = hashData("Hello, world!", baseConfig);
     expect(hash).toMatchInlineSnapshot(`"943a702d06f34599aee1f8da8ef9f7296031d699"`);
   });
 
   test("handles null algorithm", () => {
-    const hash = hashContent("Hello, world!", { ...baseConfig, hashAlgorithm: "null" });
+    const hash = hashData("Hello, world!", { ...baseConfig, hashAlgorithm: "null" });
     expect(hash).toEqual("(null)");
   });
 });

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -7,17 +7,17 @@ import type { Config, ContentHash, FileHash, Fingerprint, FingerprintOptions } f
 import { getInputFiles, getInputFilesSync, mergeHashes } from "./utils.js";
 
 export async function calculateFingerprint(
-  rootDir: string,
+  basePath: string,
   options?: FingerprintOptions,
 ): Promise<Fingerprint> {
   const inputFiles = await getInputFiles({
-    rootDir,
-    include: options?.include,
-    exclude: options?.exclude,
+    basePath,
+    files: options?.files,
+    ignores: options?.ignores,
   });
 
   const config: Config = {
-    rootDir,
+    basePath,
     hashAlgorithm: options?.hashAlgorithm,
   };
 
@@ -33,17 +33,17 @@ export async function calculateFingerprint(
 }
 
 export function calculateFingerprintSync(
-  rootDir: string,
+  basePath: string,
   options?: FingerprintOptions,
 ): Fingerprint {
   const inputFiles = getInputFilesSync({
-    rootDir,
-    include: options?.include,
-    exclude: options?.exclude,
+    basePath,
+    files: options?.files,
+    ignores: options?.ignores,
   });
 
   const config: Config = {
-    rootDir,
+    basePath,
     hashAlgorithm: options?.hashAlgorithm,
   };
 

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -14,7 +14,7 @@ import { getInputFiles, getInputFilesSync, mergeHashes } from "./utils.js";
 
 export async function calculateFingerprint(
   basePath: string,
-  { hashAlgorithm, files, ignores, contentInputs, concurrency }: FingerprintOptions = {},
+  { hashAlgorithm, files, ignores, content, concurrency }: FingerprintOptions = {},
 ): Promise<Fingerprint> {
   const config: Config = {
     basePath,
@@ -32,8 +32,8 @@ export async function calculateFingerprint(
     inputFiles.map((path) => limit(() => calculateFileHash(path, config))),
   );
 
-  const contentHashes = contentInputs
-    ? getContentInputs(contentInputs)?.map((input) => calculateContentHash(input, config))
+  const contentHashes = content
+    ? getContentInputs(content)?.map((input) => calculateContentHash(input, config))
     : [];
 
   return mergeHashes(fileHashes, contentHashes, config);
@@ -41,7 +41,7 @@ export async function calculateFingerprint(
 
 export function calculateFingerprintSync(
   basePath: string,
-  { hashAlgorithm, files, ignores, contentInputs }: FingerprintOptions = {},
+  { hashAlgorithm, files, ignores, content }: FingerprintOptions = {},
 ): Fingerprint {
   const config: Config = {
     basePath,
@@ -56,15 +56,15 @@ export function calculateFingerprintSync(
 
   const fileHashes = inputFiles.map((path) => calculateFileHashSync(path, config));
 
-  const contentHashes = contentInputs
-    ? getContentInputs(contentInputs)?.map((input) => calculateContentHash(input, config))
+  const contentHashes = content
+    ? getContentInputs(content)?.map((input) => calculateContentHash(input, config))
     : [];
 
   return mergeHashes(fileHashes, contentHashes, config);
 }
 
-function getContentInputs(contentInputs: Record<string, ContentValue>): ContentInput[] {
-  return Object.entries(contentInputs).map(([key, value]) => {
+function getContentInputs(content: Record<string, ContentValue>): ContentInput[] {
+  return Object.entries(content).map(([key, value]) => {
     return { key, ...value };
   });
 }

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -3,12 +3,12 @@ import pLimit from "p-limit";
 import { DEFAULT_CONCURRENCY } from "./constants.js";
 import { calculateContentHash } from "./inputs/content.js";
 import { calculateFileHash, calculateFileHashSync } from "./inputs/file.js";
-import type { Config, ContentHash, Fingerprint, FingerprintOptions, InputRecord } from "./types.js";
+import type { Config, Fingerprint, FingerprintOptions } from "./types.js";
 import { getInputFiles, getInputFilesSync, mergeHashes } from "./utils.js";
 
 export async function calculateFingerprint(
   basePath: string,
-  { hashAlgorithm, files, ignores, extraInputs: content, concurrency }: FingerprintOptions = {},
+  { hashAlgorithm, files, ignores, contentInputs: content, concurrency }: FingerprintOptions = {},
 ): Promise<Fingerprint> {
   const config: Config = {
     basePath,
@@ -21,13 +21,13 @@ export async function calculateFingerprint(
     inputFiles.map((path) => limit(() => calculateFileHash(path, config))),
   );
 
-  const contentHashes = calculateContentHashes(content, config);
+  const contentHashes = content?.map((input) => calculateContentHash(input, config)) ?? [];
   return mergeHashes(fileHashes, contentHashes, config);
 }
 
 export function calculateFingerprintSync(
   basePath: string,
-  { hashAlgorithm, files, ignores, extraInputs: content }: FingerprintOptions = {},
+  { hashAlgorithm, files, ignores, contentInputs: content }: FingerprintOptions = {},
 ): Fingerprint {
   const config: Config = {
     basePath,
@@ -36,15 +36,6 @@ export function calculateFingerprintSync(
 
   const inputFiles = getInputFilesSync(basePath, { files, ignores });
   const fileHashes = inputFiles.map((path) => calculateFileHashSync(path, config));
-
-  const contentHashes = calculateContentHashes(content, config);
+  const contentHashes = content?.map((input) => calculateContentHash(input, config)) ?? [];
   return mergeHashes(fileHashes, contentHashes, config);
-}
-
-function calculateContentHashes(inputs: InputRecord | undefined, config: Config): ContentHash[] {
-  if (!inputs) return [];
-
-  return Object.entries(inputs).map(([key, value]) =>
-    calculateContentHash({ key, ...value }, config),
-  );
 }

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -8,7 +8,7 @@ import { getInputFiles, getInputFilesSync, mergeHashes } from "./utils.js";
 
 export async function calculateFingerprint(
   basePath: string,
-  { hashAlgorithm, files, ignores, content, concurrency }: FingerprintOptions = {},
+  { hashAlgorithm, files, ignores, extraInputs: content, concurrency }: FingerprintOptions = {},
 ): Promise<Fingerprint> {
   const config: Config = {
     basePath,
@@ -22,13 +22,12 @@ export async function calculateFingerprint(
   );
 
   const contentHashes = content ? calculateContentHashes(content, config) : [];
-
   return mergeHashes(fileHashes, contentHashes, config);
 }
 
 export function calculateFingerprintSync(
   basePath: string,
-  { hashAlgorithm, files, ignores, content }: FingerprintOptions = {},
+  { hashAlgorithm, files, ignores, extraInputs: content }: FingerprintOptions = {},
 ): Fingerprint {
   const config: Config = {
     basePath,
@@ -37,7 +36,7 @@ export function calculateFingerprintSync(
 
   const inputFiles = getInputFilesSync(basePath, { files, ignores });
   const fileHashes = inputFiles.map((path) => calculateFileHashSync(path, config));
-  const contentHashes = content ? calculateContentHashes(content, config) : [];
 
+  const contentHashes = content ? calculateContentHashes(content, config) : [];
   return mergeHashes(fileHashes, contentHashes, config);
 }

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -3,71 +3,50 @@ import pLimit from "p-limit";
 import { DEFAULT_CONCURRENCY } from "./constants.js";
 import { calculateContentHash } from "./inputs/content.js";
 import { calculateFileHash, calculateFileHashSync } from "./inputs/file.js";
-import type {
-  Config,
-  ConfigWithBasePath,
-  FileHash,
-  Fingerprint,
-  FingerprintOptions,
-} from "./types.js";
+import type { Config, Fingerprint, FingerprintOptions } from "./types.js";
 import { getInputFiles, getInputFilesSync, mergeHashes } from "./utils.js";
 
-export async function calculateFingerprint({
-  basePath,
-  hashAlgorithm,
-  files,
-  ignores,
-  contentInputs,
-  concurrency,
-}: FingerprintOptions = {}): Promise<Fingerprint> {
+export async function calculateFingerprint(
+  basePath: string,
+  { hashAlgorithm, files, ignores, contentInputs, concurrency }: FingerprintOptions = {},
+): Promise<Fingerprint> {
   const config: Config = {
     basePath,
     hashAlgorithm,
   };
 
-  let fileHashes: FileHash[] = [];
-  if (basePath) {
-    const inputFiles = await getInputFiles({
-      basePath,
-      files,
-      ignores,
-    });
+  const inputFiles = await getInputFiles({
+    basePath,
+    files,
+    ignores,
+  });
 
-    const limit = pLimit(concurrency ?? DEFAULT_CONCURRENCY);
-    fileHashes = await Promise.all(
-      inputFiles.map((path) => limit(() => calculateFileHash(path, config as ConfigWithBasePath))),
-    );
-  }
+  const limit = pLimit(concurrency ?? DEFAULT_CONCURRENCY);
+  const fileHashes = await Promise.all(
+    inputFiles.map((path) => limit(() => calculateFileHash(path, config))),
+  );
 
   const content = contentInputs?.map((input) => calculateContentHash(input, config)) ?? [];
 
   return mergeHashes(fileHashes, content, config);
 }
 
-export function calculateFingerprintSync({
-  basePath,
-  hashAlgorithm,
-  files,
-  ignores,
-  contentInputs,
-}: FingerprintOptions = {}): Fingerprint {
+export function calculateFingerprintSync(
+  basePath: string,
+  { hashAlgorithm, files, ignores, contentInputs }: FingerprintOptions = {},
+): Fingerprint {
   const config: Config = {
     basePath,
     hashAlgorithm,
   };
 
-  let fileHashes: FileHash[] = [];
-  if (basePath) {
-    const inputFiles = getInputFilesSync({
-      basePath,
-      files,
-      ignores,
-    });
+  const inputFiles = getInputFilesSync({
+    basePath,
+    files,
+    ignores,
+  });
 
-    fileHashes = inputFiles.map((path) =>
-      calculateFileHashSync(path, config as ConfigWithBasePath),
-    );
-  }
+  const fileHashes = inputFiles.map((path) => calculateFileHashSync(path, config));
 
   const contentHashes = contentInputs?.map((input) => calculateContentHash(input, config)) ?? [];
 

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -1,15 +1,9 @@
 import pLimit from "p-limit";
 
 import { DEFAULT_CONCURRENCY } from "./constants.js";
-import { calculateContentHash } from "./inputs/content.js";
+import { calculateContentHashes } from "./inputs/content.js";
 import { calculateFileHash, calculateFileHashSync } from "./inputs/file.js";
-import type {
-  Config,
-  ContentInput,
-  ContentValue,
-  Fingerprint,
-  FingerprintOptions,
-} from "./types.js";
+import type { Config, Fingerprint, FingerprintOptions } from "./types.js";
 import { getInputFiles, getInputFilesSync, mergeHashes } from "./utils.js";
 
 export async function calculateFingerprint(
@@ -32,9 +26,7 @@ export async function calculateFingerprint(
     inputFiles.map((path) => limit(() => calculateFileHash(path, config))),
   );
 
-  const contentHashes = content
-    ? getContentInputs(content)?.map((input) => calculateContentHash(input, config))
-    : [];
+  const contentHashes = content ? calculateContentHashes(content, config) : [];
 
   return mergeHashes(fileHashes, contentHashes, config);
 }
@@ -55,16 +47,7 @@ export function calculateFingerprintSync(
   });
 
   const fileHashes = inputFiles.map((path) => calculateFileHashSync(path, config));
-
-  const contentHashes = content
-    ? getContentInputs(content)?.map((input) => calculateContentHash(input, config))
-    : [];
+  const contentHashes = content ? calculateContentHashes(content, config) : [];
 
   return mergeHashes(fileHashes, contentHashes, config);
-}
-
-function getContentInputs(content: Record<string, ContentValue>): ContentInput[] {
-  return Object.entries(content).map(([key, value]) => {
-    return { key, ...value };
-  });
 }

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -17,7 +17,7 @@ export async function calculateFingerprint({
   hashAlgorithm,
   files,
   ignores,
-  extraInputs,
+  contentInputs,
   concurrency,
 }: FingerprintOptions = {}): Promise<Fingerprint> {
   const config: Config = {
@@ -39,7 +39,7 @@ export async function calculateFingerprint({
     );
   }
 
-  const content = extraInputs?.map((input) => calculateContentHash(input, config)) ?? [];
+  const content = contentInputs?.map((input) => calculateContentHash(input, config)) ?? [];
 
   return mergeHashes(fileHashes, content, config);
 }
@@ -49,7 +49,7 @@ export function calculateFingerprintSync({
   hashAlgorithm,
   files,
   ignores,
-  extraInputs,
+  contentInputs,
 }: FingerprintOptions = {}): Fingerprint {
   const config: Config = {
     basePath,
@@ -69,7 +69,7 @@ export function calculateFingerprintSync({
     );
   }
 
-  const contentHashes = extraInputs?.map((input) => calculateContentHash(input, config)) ?? [];
+  const contentHashes = contentInputs?.map((input) => calculateContentHash(input, config)) ?? [];
 
   return mergeHashes(fileHashes, contentHashes, config);
 }

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -15,13 +15,8 @@ export async function calculateFingerprint(
     hashAlgorithm,
   };
 
-  const inputFiles = await getInputFiles({
-    basePath,
-    files,
-    ignores,
-  });
-
   const limit = pLimit(concurrency ?? DEFAULT_CONCURRENCY);
+  const inputFiles = await getInputFiles(basePath, { files, ignores });
   const fileHashes = await Promise.all(
     inputFiles.map((path) => limit(() => calculateFileHash(path, config))),
   );
@@ -40,12 +35,7 @@ export function calculateFingerprintSync(
     hashAlgorithm,
   };
 
-  const inputFiles = getInputFilesSync({
-    basePath,
-    files,
-    ignores,
-  });
-
+  const inputFiles = getInputFilesSync(basePath, { files, ignores });
   const fileHashes = inputFiles.map((path) => calculateFileHashSync(path, config));
   const contentHashes = content ? calculateContentHashes(content, config) : [];
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -3,11 +3,13 @@ import * as nodePath from "node:path";
 import { escapePath } from "tinyglobby";
 
 export interface GetGitIgnoredPathsOptions {
-  basePath: string;
   entireRepo?: boolean;
 }
 
-export function getGitIgnoredPaths({ basePath, entireRepo }: GetGitIgnoredPathsOptions): string[] {
+export function getGitIgnoredPaths(
+  basePath: string,
+  { entireRepo }: GetGitIgnoredPathsOptions = {},
+): string[] {
   const cwd = entireRepo ? getGitRootPath(basePath) : nodePath.resolve(basePath);
 
   try {

--- a/src/git.ts
+++ b/src/git.ts
@@ -6,8 +6,11 @@ export interface GetGitIgnoredPathsOptions {
   entireRepo?: boolean;
 }
 
-export function getGitIgnoredPaths(path: string, options?: GetGitIgnoredPathsOptions): string[] {
-  const cwd = options?.entireRepo ? getGitRootPath(path) : path;
+export function getGitIgnoredPaths(
+  basePath: string,
+  options?: GetGitIgnoredPathsOptions,
+): string[] {
+  const cwd = options?.entireRepo ? getGitRootPath(basePath) : basePath;
 
   try {
     const output = execSync("git ls-files -z --others --ignored --exclude-standard --directory", {
@@ -22,7 +25,7 @@ export function getGitIgnoredPaths(path: string, options?: GetGitIgnoredPathsOpt
       .map((filePath) => escapePath(filePath));
 
     if (options?.entireRepo) {
-      result = result.map((filePath) => remapPaths(filePath, cwd, path));
+      result = result.map((filePath) => remapPaths(filePath, cwd, basePath));
     }
 
     return result.sort();
@@ -51,9 +54,9 @@ function getGitRootPath(path: string): string {
   }
 }
 
-export function remapPaths(path: string, fromRoot: string, toRoot: string): string {
+export function remapPaths(path: string, fromBase: string, toBase: string): string {
   const rebasedPath = nodePath
-    .relative(toRoot, nodePath.join(fromRoot, path))
+    .relative(toBase, nodePath.join(fromBase, path))
     .split(nodePath.sep)
     .join("/");
   if (path.endsWith("/") && !rebasedPath.endsWith("/")) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -3,14 +3,12 @@ import * as nodePath from "node:path";
 import { escapePath } from "tinyglobby";
 
 export interface GetGitIgnoredPathsOptions {
+  basePath: string;
   entireRepo?: boolean;
 }
 
-export function getGitIgnoredPaths(
-  basePath: string,
-  options?: GetGitIgnoredPathsOptions,
-): string[] {
-  const cwd = options?.entireRepo ? getGitRootPath(basePath) : basePath;
+export function getGitIgnoredPaths({ basePath, entireRepo }: GetGitIgnoredPathsOptions): string[] {
+  const cwd = entireRepo ? getGitRootPath(basePath) : basePath;
 
   try {
     const output = execSync("git ls-files -z --others --ignored --exclude-standard --directory", {
@@ -24,7 +22,7 @@ export function getGitIgnoredPaths(
       .filter(Boolean)
       .map((filePath) => escapePath(filePath));
 
-    if (options?.entireRepo) {
+    if (entireRepo) {
       result = result.map((filePath) => remapPaths(filePath, cwd, basePath));
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { calculateFingerprint, calculateFingerprintSync } from "./fingerprint.js";
 export { calculateFileHash, calculateFileHashSync } from "./inputs/file.js";
-export { calculateContentHash } from "./inputs/content.js";
+export { calculateContentHash, textContent, jsonContent, envContent } from "./inputs/content.js";
 export { getGitIgnoredPaths } from "./git.js";
 export { hashContent, mergeHashes } from "./utils.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ export { calculateFingerprint, calculateFingerprintSync } from "./fingerprint.js
 export { calculateFileHash, calculateFileHashSync } from "./inputs/file.js";
 export { calculateContentHash, textContent, jsonContent, envContent } from "./inputs/content.js";
 export { getGitIgnoredPaths } from "./git.js";
-export { hashContent, mergeHashes } from "./utils.js";
+export { hashData, mergeHashes } from "./utils.js";
 
 export type * from "./types.js";

--- a/src/inputs/__tests__/content.test.ts
+++ b/src/inputs/__tests__/content.test.ts
@@ -1,57 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { formatContentHashes } from "../../../test-utils/format.js";
 import { EMPTY_HASH } from "../../constants.js";
 import type { Config, ContentInput } from "../../types.js";
-import {
-  calculateContentHash,
-  calculateContentHashes,
-  envContent,
-  jsonContent,
-  textContent,
-} from "../content.js";
+import { calculateContentHash, envContent, jsonContent } from "../content.js";
 
 const baseConfig: Config = {
   basePath: "not-used",
 };
-
-describe("calculateContentHashes", () => {
-  test("handles empty input", () => {
-    const hashes = calculateContentHashes({}, baseConfig);
-    expect(hashes).toEqual([]);
-  });
-
-  test("returns same hash for equal content", () => {
-    const contents1 = {
-      "content-1": textContent("Hello, world!"),
-      "json-1": jsonContent({ foo: "bar", baz: 123 }),
-      "env-1": envContent(["TEST_ENV_1", "TEST_ENV_2"]),
-    };
-
-    const contents2 = {
-      "env-1": envContent(["TEST_ENV_1", "TEST_ENV_2"]),
-      "json-1": jsonContent({ foo: "bar", baz: 123 }),
-      "content-1": textContent("Hello, world!"),
-    };
-
-    const hashes1 = calculateContentHashes(contents1, baseConfig);
-    expect(formatContentHashes(hashes1)).toMatchInlineSnapshot(`
-      "- content-1 - 943a702d06f34599aee1f8da8ef9f7296031d699 - Hello, world!
-      - env-1 - 94ea284f1c2e92defededc9a4ba430af0612be2b - {
-        "TEST_ENV_1": "",
-        "TEST_ENV_2": ""
-      }
-      - json-1 - 7391dce2d9080f78b92f62bb43b308a2f073b0e5 - {
-        "baz": 123,
-        "foo": "bar"
-      }
-      "
-    `);
-
-    const hashes2 = calculateContentHashes(contents2, baseConfig);
-    expect(hashes1).toEqual(hashes2);
-  });
-});
 
 describe("calculateContentHash", () => {
   test("handles regular content", () => {

--- a/src/inputs/__tests__/content.test.ts
+++ b/src/inputs/__tests__/content.test.ts
@@ -108,24 +108,6 @@ describe("calculateContentHash", () => {
     expect(hash).toEqual(hash2);
   });
 
-  test("handles null hash algorithm", () => {
-    const content = jsonContent("json-1", { foo: "bar" });
-
-    const testConfig = { ...baseConfig, hashAlgorithm: "null" };
-    const hash = calculateContentHash(content, testConfig);
-    expect(hash).toMatchInlineSnapshot(`
-    {
-      "content": 
-    "{
-      "foo": "bar"
-    }"
-    ,
-      "hash": "(null)",
-      "key": "json-1",
-    }
-  `);
-  });
-
   test("handles env input", () => {
     process.env["TEST_ENV_1"] = "value1";
     process.env["TEST_ENV_2"] = "value2";
@@ -153,8 +135,9 @@ describe("calculateContentHash", () => {
 
   test('content handles "secret" option', () => {
     const content = textContent("content-1", "MY-SECRET-CONTENT");
+    const secretContent = textContent("content-1", "MY-SECRET-CONTENT", { secret: true });
 
-    const hash = calculateContentHash({ ...content, secret: true }, baseConfig);
+    const hash = calculateContentHash(secretContent, baseConfig);
     expect(hash).toMatchInlineSnapshot(`
       {
         "content": undefined,

--- a/src/inputs/__tests__/content.test.ts
+++ b/src/inputs/__tests__/content.test.ts
@@ -1,12 +1,57 @@
 import { describe, expect, test } from "bun:test";
 
+import { formatContentHashes } from "../../../test-utils/format.js";
 import { EMPTY_HASH } from "../../constants.js";
 import type { Config, ContentInput } from "../../types.js";
-import { calculateContentHash, envContent, jsonContent } from "../content.js";
+import {
+  calculateContentHash,
+  calculateContentHashes,
+  envContent,
+  jsonContent,
+  textContent,
+} from "../content.js";
 
 const baseConfig: Config = {
   basePath: "not-used",
 };
+
+describe("calculateContentHashes", () => {
+  test("handles empty input", () => {
+    const hashes = calculateContentHashes({}, baseConfig);
+    expect(hashes).toEqual([]);
+  });
+
+  test("returns same hash for equal content", () => {
+    const contents1 = {
+      "content-1": textContent("Hello, world!"),
+      "json-1": jsonContent({ foo: "bar", baz: 123 }),
+      "env-1": envContent(["TEST_ENV_1", "TEST_ENV_2"]),
+    };
+
+    const contents2 = {
+      "env-1": envContent(["TEST_ENV_1", "TEST_ENV_2"]),
+      "json-1": jsonContent({ foo: "bar", baz: 123 }),
+      "content-1": textContent("Hello, world!"),
+    };
+
+    const hashes1 = calculateContentHashes(contents1, baseConfig);
+    expect(formatContentHashes(hashes1)).toMatchInlineSnapshot(`
+      "- content-1 - 943a702d06f34599aee1f8da8ef9f7296031d699 - Hello, world!
+      - env-1 - 94ea284f1c2e92defededc9a4ba430af0612be2b - {
+        "TEST_ENV_1": "",
+        "TEST_ENV_2": ""
+      }
+      - json-1 - 7391dce2d9080f78b92f62bb43b308a2f073b0e5 - {
+        "baz": 123,
+        "foo": "bar"
+      }
+      "
+    `);
+
+    const hashes2 = calculateContentHashes(contents2, baseConfig);
+    expect(hashes1).toEqual(hashes2);
+  });
+});
 
 describe("calculateContentHash", () => {
   test("handles regular content", () => {

--- a/src/inputs/__tests__/content.test.ts
+++ b/src/inputs/__tests__/content.test.ts
@@ -146,6 +146,9 @@ describe("calculateContentHash", () => {
         "key": "env-1",
       }
     `);
+
+    delete process.env["TEST_ENV_1"];
+    delete process.env["TEST_ENV_2"];
   });
 
   test('content handles "secret" option', () => {

--- a/src/inputs/__tests__/content.test.ts
+++ b/src/inputs/__tests__/content.test.ts
@@ -5,7 +5,7 @@ import type { Config, ContentInput, JsonInput } from "../../types.js";
 import { calculateContentHash } from "../content.js";
 
 const baseConfig: Config = {
-  rootDir: "not-used",
+  basePath: "not-used",
 };
 
 describe("calculateContentHash", () => {

--- a/src/inputs/__tests__/file.test.ts
+++ b/src/inputs/__tests__/file.test.ts
@@ -2,12 +2,12 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { createRootDir } from "../../../test-utils/fs.js";
 import { EMPTY_HASH } from "../../constants.js";
-import type { Config } from "../../types.js";
+import type { ConfigWithBasePath } from "../../types.js";
 import { calculateFileHash, calculateFileHashSync } from "../file.js";
 
 const { basePath, prepareRootDir, writeFile } = createRootDir("file-test");
 
-const baseConfig: Config = {
+const baseConfig: ConfigWithBasePath = {
   basePath,
   hashAlgorithm: "sha1",
 };

--- a/src/inputs/__tests__/file.test.ts
+++ b/src/inputs/__tests__/file.test.ts
@@ -5,10 +5,10 @@ import { EMPTY_HASH } from "../../constants.js";
 import type { Config } from "../../types.js";
 import { calculateFileHash, calculateFileHashSync } from "../file.js";
 
-const { rootDir, prepareRootDir, writeFile } = createRootDir("file-test");
+const { basePath, prepareRootDir, writeFile } = createRootDir("file-test");
 
 const baseConfig: Config = {
-  rootDir,
+  basePath,
   hashAlgorithm: "sha1",
 };
 

--- a/src/inputs/__tests__/file.test.ts
+++ b/src/inputs/__tests__/file.test.ts
@@ -2,12 +2,12 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { createRootDir } from "../../../test-utils/fs.js";
 import { EMPTY_HASH } from "../../constants.js";
-import type { ConfigWithBasePath } from "../../types.js";
+import type { Config } from "../../types.js";
 import { calculateFileHash, calculateFileHashSync } from "../file.js";
 
 const { basePath, prepareRootDir, writeFile } = createRootDir("file-test");
 
-const baseConfig: ConfigWithBasePath = {
+const baseConfig: Config = {
   basePath,
   hashAlgorithm: "sha1",
 };

--- a/src/inputs/__tests__/file.test.ts
+++ b/src/inputs/__tests__/file.test.ts
@@ -50,4 +50,34 @@ describe("calculateFileHash", () => {
     const hashSync = calculateFileHashSync("file-1.txt", testConfig);
     expect(hashSync).toEqual(hash);
   });
+
+  test("handles multiline content", async () => {
+    writeFile("file-1.txt", "Hello, world!\nThis is a test.\nMany lines.\n");
+
+    const hash = await calculateFileHash("file-1.txt", baseConfig);
+    expect(hash).toMatchInlineSnapshot(`
+      {
+        "hash": "ceb17e61ef244ea43608706b5a8d8f3988be3088",
+        "path": "file-1.txt",
+      }
+    `);
+
+    const hashSync = calculateFileHashSync("file-1.txt", baseConfig);
+    expect(hashSync).toEqual(hash);
+  });
+
+  test("handles unicode chars, emojis, etc content", async () => {
+    writeFile("file-1.txt", "Hello, world!\nąęśćź🍓🫆🌀\n");
+
+    const hash = await calculateFileHash("file-1.txt", baseConfig);
+    expect(hash).toMatchInlineSnapshot(`
+      {
+        "hash": "98319057a3032de4f5f835bfd87d493f9bed8ba9",
+        "path": "file-1.txt",
+      }
+    `);
+
+    const hashSync = calculateFileHashSync("file-1.txt", baseConfig);
+    expect(hashSync).toEqual(hash);
+  });
 });

--- a/src/inputs/content.ts
+++ b/src/inputs/content.ts
@@ -1,11 +1,5 @@
-import type { Config, ContentHash, ContentInput, InputRecord } from "../types.js";
+import type { Config, ContentHash, ContentInput } from "../types.js";
 import { hashData } from "../utils.js";
-
-export function calculateContentHashes(inputs: InputRecord, config: Config): ContentHash[] {
-  return Object.entries(inputs)
-    .map(([key, value]) => calculateContentHash({ key, ...value }, config))
-    .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
-}
 
 export function calculateContentHash(input: ContentInput, config: Config): ContentHash {
   return {

--- a/src/inputs/content.ts
+++ b/src/inputs/content.ts
@@ -1,10 +1,7 @@
-import type { Config, ContentHash, ContentInput, ContentValue } from "../types.js";
-import { hashContent } from "../utils.js";
+import type { Config, ContentHash, ContentInput, InputRecord } from "../types.js";
+import { hashData } from "../utils.js";
 
-export function calculateContentHashes(
-  inputs: Record<string, ContentValue>,
-  config: Config,
-): ContentHash[] {
+export function calculateContentHashes(inputs: InputRecord, config: Config): ContentHash[] {
   return Object.entries(inputs)
     .map(([key, value]) => calculateContentHash({ key, ...value }, config))
     .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
@@ -13,19 +10,25 @@ export function calculateContentHashes(
 export function calculateContentHash(input: ContentInput, config: Config): ContentHash {
   return {
     key: input.key,
-    hash: hashContent(input.content, config),
+    hash: hashData(input.content, config),
     content: input.secret ? undefined : input.content,
   };
 }
 
-export function textContent(text: string, options?: { secret?: boolean }): ContentValue {
+export function textContent(
+  text: string,
+  options?: { secret?: boolean },
+): Omit<ContentInput, "key"> {
   return {
     content: text,
     secret: options?.secret,
   };
 }
 
-export function jsonContent(json: unknown, options?: { secret?: boolean }): ContentValue {
+export function jsonContent(
+  json: unknown,
+  options?: { secret?: boolean },
+): Omit<ContentInput, "key"> {
   const content = safeJsonStringify(normalizeJson(json));
   return {
     content,
@@ -33,7 +36,10 @@ export function jsonContent(json: unknown, options?: { secret?: boolean }): Cont
   };
 }
 
-export function envContent(envs: string[], options?: { secret?: boolean }): ContentValue {
+export function envContent(
+  envs: string[],
+  options?: { secret?: boolean },
+): Omit<ContentInput, "key"> {
   const envJson: Record<string, string | undefined> = {};
   for (const key of envs) {
     envJson[key] = process.env[key] ?? "";

--- a/src/inputs/content.ts
+++ b/src/inputs/content.ts
@@ -10,36 +10,42 @@ export function calculateContentHash(input: ContentInput, config: Config): Conte
 }
 
 export function textContent(
+  key: string,
   text: string,
   options?: { secret?: boolean },
-): Omit<ContentInput, "key"> {
+): ContentInput {
   return {
+    key,
     content: text,
     secret: options?.secret,
   };
 }
 
 export function jsonContent(
+  key: string,
   json: unknown,
   options?: { secret?: boolean },
-): Omit<ContentInput, "key"> {
+): ContentInput {
   const content = safeJsonStringify(normalizeJson(json));
   return {
+    key,
     content,
     secret: options?.secret,
   };
 }
 
 export function envContent(
+  key: string,
   envs: string[],
   options?: { secret?: boolean },
-): Omit<ContentInput, "key"> {
+): ContentInput {
   const envJson: Record<string, string | undefined> = {};
   for (const key of envs) {
     envJson[key] = process.env[key] ?? "";
   }
 
   return {
+    key,
     content: safeJsonStringify(normalizeJson(envJson)),
     secret: options?.secret,
   };

--- a/src/inputs/content.ts
+++ b/src/inputs/content.ts
@@ -1,6 +1,15 @@
 import type { Config, ContentHash, ContentInput, ContentValue } from "../types.js";
 import { hashContent } from "../utils.js";
 
+export function calculateContentHashes(
+  inputs: Record<string, ContentValue>,
+  config: Config,
+): ContentHash[] {
+  return Object.entries(inputs)
+    .map(([key, value]) => calculateContentHash({ key, ...value }, config))
+    .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+}
+
 export function calculateContentHash(input: ContentInput, config: Config): ContentHash {
   return {
     key: input.key,

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -15,7 +15,7 @@ export async function calculateFileHash(path: string, config: Config): Promise<F
     };
   }
 
-  const pathWithRoot = join(config.rootDir, path);
+  const pathWithRoot = join(config.basePath, path);
   const content = await readFile(pathWithRoot, "utf8");
   return {
     path: normalizedPath,
@@ -32,7 +32,7 @@ export function calculateFileHashSync(path: string, config: Config): FileHash {
     };
   }
 
-  const pathWithRoot = join(config.rootDir, path);
+  const pathWithRoot = join(config.basePath, path);
   const content = readFileSync(pathWithRoot, "utf8");
   return {
     path: normalizedPath,

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -15,8 +15,8 @@ export async function calculateFileHash(path: string, config: Config): Promise<F
     };
   }
 
-  const pathWithRoot = join(config.basePath, path);
-  const content = await readFile(pathWithRoot, "utf8");
+  const pathWithBase = join(config.basePath, path);
+  const content = await readFile(pathWithBase, "utf8");
   return {
     path: normalizedPath,
     hash: hashContent(content, config),
@@ -32,8 +32,8 @@ export function calculateFileHashSync(path: string, config: Config): FileHash {
     };
   }
 
-  const pathWithRoot = join(config.basePath, path);
-  const content = readFileSync(pathWithRoot, "utf8");
+  const pathWithBase = join(config.basePath, path);
+  const content = readFileSync(pathWithBase, "utf8");
   return {
     path: normalizedPath,
     hash: hashContent(content, config),

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -3,10 +3,13 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { EMPTY_HASH } from "../constants.js";
-import type { Config, FileHash } from "../types.js";
+import type { ConfigWithBasePath, FileHash } from "../types.js";
 import { hashContent, normalizeFilePath } from "../utils.js";
 
-export async function calculateFileHash(path: string, config: Config): Promise<FileHash> {
+export async function calculateFileHash(
+  path: string,
+  config: ConfigWithBasePath,
+): Promise<FileHash> {
   const normalizedPath = normalizeFilePath(path);
   if (config.hashAlgorithm === "null") {
     return {
@@ -23,7 +26,7 @@ export async function calculateFileHash(path: string, config: Config): Promise<F
   };
 }
 
-export function calculateFileHashSync(path: string, config: Config): FileHash {
+export function calculateFileHashSync(path: string, config: ConfigWithBasePath): FileHash {
   const normalizedPath = normalizeFilePath(path);
   if (config.hashAlgorithm === "null") {
     return {

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { EMPTY_HASH } from "../constants.js";
 import type { Config, FileHash } from "../types.js";
-import { hashContent, normalizeFilePath } from "../utils.js";
+import { hashData, normalizeFilePath } from "../utils.js";
 
 export async function calculateFileHash(path: string, config: Config): Promise<FileHash> {
   const normalizedPath = normalizeFilePath(path);
@@ -19,7 +19,7 @@ export async function calculateFileHash(path: string, config: Config): Promise<F
   const content = await readFile(pathWithBase, "utf8");
   return {
     path: normalizedPath,
-    hash: hashContent(content, config),
+    hash: hashData(content, config),
   };
 }
 
@@ -36,6 +36,6 @@ export function calculateFileHashSync(path: string, config: Config): FileHash {
   const content = readFileSync(pathWithBase, "utf8");
   return {
     path: normalizedPath,
-    hash: hashContent(content, config),
+    hash: hashData(content, config),
   };
 }

--- a/src/inputs/file.ts
+++ b/src/inputs/file.ts
@@ -3,13 +3,10 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { EMPTY_HASH } from "../constants.js";
-import type { ConfigWithBasePath, FileHash } from "../types.js";
+import type { Config, FileHash } from "../types.js";
 import { hashContent, normalizeFilePath } from "../utils.js";
 
-export async function calculateFileHash(
-  path: string,
-  config: ConfigWithBasePath,
-): Promise<FileHash> {
+export async function calculateFileHash(path: string, config: Config): Promise<FileHash> {
   const normalizedPath = normalizeFilePath(path);
   if (config.hashAlgorithm === "null") {
     return {
@@ -26,7 +23,7 @@ export async function calculateFileHash(
   };
 }
 
-export function calculateFileHashSync(path: string, config: ConfigWithBasePath): FileHash {
+export function calculateFileHashSync(path: string, config: Config): FileHash {
   const normalizedPath = normalizeFilePath(path);
   if (config.hashAlgorithm === "null") {
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface FingerprintOptions {
   ignores?: readonly string[];
 
   /** Extra inputs to include in the fingerprint: text, json, etc */
-  extraInputs?: InputRecord;
+  contentInputs?: ContentInput[];
 
   /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;
@@ -31,8 +31,6 @@ export interface Config {
   basePath: string;
   hashAlgorithm?: HashAlgorithm;
 }
-
-export type InputRecord = { [key: string]: Omit<ContentInput, "key"> };
 
 export interface ContentInput {
   key: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface FingerprintOptions {
   ignores?: readonly string[];
 
   /** Extra inputs to include in the fingerprint: content, json, etc */
-  extraInputs?: Input[];
+  contentInputs?: Input[];
 
   /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface FingerprintOptions {
   ignores?: readonly string[];
 
   /** Extra inputs to include in the fingerprint: text, json, etc */
-  contentInputs?: ContentInput[];
+  contentInputs?: readonly ContentInput[];
 
   /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,11 @@ type StringWithAutoSuggest<T> = (string & {}) | T;
 export type HashAlgorithm = StringWithAutoSuggest<"sha1" | "sha256" | "sha512">;
 
 export interface FingerprintOptions {
-  /** File and directory paths to include (does NOT support globs) */
-  include?: readonly string[];
+  /** Glob patterns indicating files (and directories) to include */
+  files?: readonly string[];
 
-  /** Paths to exclude (support globs, "picomatch" syntax) */
-  exclude?: ReadonlyArray<string>;
+  /** Glob patterns indicating files (and directories) to ignore */
+  ignores?: ReadonlyArray<string>;
 
   /** Extra inputs to include in the fingerprint: content, json, etc */
   extraInputs?: Input[];
@@ -28,7 +28,7 @@ export interface FingerprintOptions {
  * Internal fingerprint config. Can change without semver.
  */
 export interface Config {
-  rootDir: string;
+  basePath: string;
   hashAlgorithm?: HashAlgorithm;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,8 +14,8 @@ export interface FingerprintOptions {
   /** Glob patterns indicating files (and directories) to ignore */
   ignores?: readonly string[];
 
-  /** Extra inputs to include in the fingerprint: content, json, etc */
-  content?: Record<string, ContentValue>;
+  /** Extra inputs to include in the fingerprint: text, json, etc */
+  extraInputs?: InputRecord;
 
   /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;
@@ -32,13 +32,10 @@ export interface Config {
   hashAlgorithm?: HashAlgorithm;
 }
 
+export type InputRecord = { [key: string]: Omit<ContentInput, "key"> };
+
 export interface ContentInput {
   key: string;
-  content: string;
-  secret?: boolean;
-}
-
-export interface ContentValue {
   content: string;
   secret?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,6 @@ type StringWithAutoSuggest<T> = (string & {}) | T;
 export type HashAlgorithm = StringWithAutoSuggest<"sha1" | "sha256" | "sha512">;
 
 export interface FingerprintOptions {
-  /** Base path for the fingerprint calculation */
-  basePath?: string;
-
   /** Glob patterns indicating files (and directories) to include */
   files?: readonly string[];
 
@@ -31,11 +28,6 @@ export interface FingerprintOptions {
  * Internal fingerprint config. Can change without semver.
  */
 export interface Config {
-  basePath?: string;
-  hashAlgorithm?: HashAlgorithm;
-}
-
-export interface ConfigWithBasePath {
   basePath: string;
   hashAlgorithm?: HashAlgorithm;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface FingerprintOptions {
   ignores?: readonly string[];
 
   /** Extra inputs to include in the fingerprint: content, json, etc */
-  contentInputs?: Input[];
+  contentInputs?: Record<string, ContentValue>;
 
   /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;
@@ -32,23 +32,14 @@ export interface Config {
   hashAlgorithm?: HashAlgorithm;
 }
 
-export type Input = ContentInput | JsonInput | EnvInput;
-
 export interface ContentInput {
   key: string;
   content: string;
   secret?: boolean;
 }
 
-export interface JsonInput {
-  key: string;
-  json: unknown;
-  secret?: boolean;
-}
-
-export interface EnvInput {
-  key: string;
-  envs: string[];
+export interface ContentValue {
+  content: string;
   secret?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface FingerprintOptions {
   files?: readonly string[];
 
   /** Glob patterns indicating files (and directories) to ignore */
-  ignores?: ReadonlyArray<string>;
+  ignores?: readonly string[];
 
   /** Extra inputs to include in the fingerprint: content, json, etc */
   extraInputs?: Input[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface FingerprintOptions {
   ignores?: readonly string[];
 
   /** Extra inputs to include in the fingerprint: content, json, etc */
-  contentInputs?: Record<string, ContentValue>;
+  content?: Record<string, ContentValue>;
 
   /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,9 @@ type StringWithAutoSuggest<T> = (string & {}) | T;
 export type HashAlgorithm = StringWithAutoSuggest<"sha1" | "sha256" | "sha512">;
 
 export interface FingerprintOptions {
+  /** Base path for the fingerprint calculation */
+  basePath?: string;
+
   /** Glob patterns indicating files (and directories) to include */
   files?: readonly string[];
 
@@ -28,6 +31,11 @@ export interface FingerprintOptions {
  * Internal fingerprint config. Can change without semver.
  */
 export interface Config {
+  basePath?: string;
+  hashAlgorithm?: HashAlgorithm;
+}
+
+export interface ConfigWithBasePath {
   basePath: string;
   hashAlgorithm?: HashAlgorithm;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,12 +19,8 @@ export function mergeHashes(
   contentHashes: readonly ContentHash[],
   config: Config,
 ): Fingerprint {
-  const sortedFileHashes = [...fileHashes].sort((a, b) =>
-    a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
-  );
-  const sortedContentHashes = [...contentHashes].sort((a, b) =>
-    a.key < b.key ? -1 : a.key > b.key ? 1 : 0,
-  );
+  const sortedFileHashes = sortBy([...fileHashes], (h) => h.path);
+  const sortedContentHashes = sortBy([...contentHashes], (h) => h.key);
   if (config.hashAlgorithm === "null") {
     return {
       hash: EMPTY_HASH,
@@ -92,4 +88,12 @@ export function getInputFilesSync(
 
 export function normalizeFilePath(path: string): string {
   return path.startsWith("./") ? path.slice(2) : path;
+}
+
+export function sortBy<T>(list: T[], selector: (item: T) => string): T[] {
+  return list.sort((a, b) => {
+    const aKey = selector(a);
+    const bKey = selector(b);
+    return aKey < bKey ? -1 : aKey > bKey ? 1 : 0;
+  });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,19 +54,19 @@ export function mergeHashes(
 }
 
 export type GetInputFilesOptions = {
-  rootDir: string;
-  include?: readonly string[];
-  exclude?: readonly string[];
+  basePath: string;
+  files?: readonly string[];
+  ignores?: readonly string[];
 };
 
 export async function getInputFiles({
-  rootDir,
-  include = ["**"],
-  exclude,
+  basePath,
+  files = ["**"],
+  ignores,
 }: GetInputFilesOptions): Promise<string[]> {
-  const paths = await glob(include, {
-    cwd: rootDir,
-    ignore: exclude,
+  const paths = await glob(files, {
+    cwd: basePath,
+    ignore: ignores,
     expandDirectories: true,
   });
 
@@ -75,13 +75,13 @@ export async function getInputFiles({
 }
 
 export function getInputFilesSync({
-  rootDir,
-  include = ["**"],
-  exclude,
+  basePath,
+  files = ["**"],
+  ignores,
 }: GetInputFilesOptions): string[] {
-  const paths = globSync(include, {
-    cwd: rootDir,
-    ignore: exclude,
+  const paths = globSync(files, {
+    cwd: basePath,
+    ignore: ignores,
     expandDirectories: true,
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,16 +58,14 @@ export function mergeHashes(
 }
 
 export type GetInputFilesOptions = {
-  basePath: string;
   files?: readonly string[];
   ignores?: readonly string[];
 };
 
-export async function getInputFiles({
-  basePath,
-  files = ["**"],
-  ignores,
-}: GetInputFilesOptions): Promise<string[]> {
+export async function getInputFiles(
+  basePath: string,
+  { files = ["**"], ignores }: GetInputFilesOptions,
+): Promise<string[]> {
   const paths = await glob(files, {
     cwd: basePath,
     ignore: ignores,
@@ -78,11 +76,10 @@ export async function getInputFiles({
   return paths;
 }
 
-export function getInputFilesSync({
-  basePath,
-  files = ["**"],
-  ignores,
-}: GetInputFilesOptions): string[] {
+export function getInputFilesSync(
+  basePath: string,
+  { files = ["**"], ignores }: GetInputFilesOptions,
+): string[] {
   const paths = globSync(files, {
     cwd: basePath,
     ignore: ignores,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { glob, globSync } from "tinyglobby";
 import { DEFAULT_HASH_ALGORITHM, EMPTY_HASH } from "./constants.js";
 import type { Config, ContentHash, FileHash, Fingerprint } from "./types.js";
 
-export function hashContent(content: string | Uint8Array, config: Config) {
+export function hashData(content: string | Uint8Array, config: Config) {
   if (config.hashAlgorithm === "null") {
     return EMPTY_HASH;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,8 +19,12 @@ export function mergeHashes(
   contentHashes: readonly ContentHash[],
   config: Config,
 ): Fingerprint {
-  const sortedFileHashes = [...fileHashes].sort();
-  const sortedContentHashes = [...contentHashes].sort();
+  const sortedFileHashes = [...fileHashes].sort((a, b) =>
+    a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
+  );
+  const sortedContentHashes = [...contentHashes].sort((a, b) =>
+    a.key < b.key ? -1 : a.key > b.key ? 1 : 0,
+  );
   if (config.hashAlgorithm === "null") {
     return {
       hash: EMPTY_HASH,

--- a/test-utils/format.ts
+++ b/test-utils/format.ts
@@ -1,4 +1,4 @@
-import type { Fingerprint } from "../src/index.js";
+import type { ContentHash, Fingerprint } from "../src/index.js";
 
 export function formatFingerprint(fingerprint: Fingerprint): string {
   let result = `Hash: ${fingerprint.hash}\n`;
@@ -13,5 +13,13 @@ export function formatFingerprint(fingerprint: Fingerprint): string {
     result += `- ${input.key} - ${input.hash}\n`;
   }
 
+  return result;
+}
+
+export function formatContentHashes(contentHashes: ContentHash[]): string {
+  let result = "";
+  for (const entry of contentHashes) {
+    result += `- ${entry.key} - ${entry.hash} - ${entry.content}\n`;
+  }
   return result;
 }

--- a/test-utils/fs.ts
+++ b/test-utils/fs.ts
@@ -3,44 +3,44 @@ import * as os from "node:os";
 import * as nodePath from "node:path";
 
 export function createRootDir(testName: string) {
-  const rootDir = nodePath.join(os.tmpdir(), testName);
-  fs.mkdirSync(rootDir, { recursive: true });
+  const basePath = nodePath.join(os.tmpdir(), testName);
+  fs.mkdirSync(basePath, { recursive: true });
 
   return {
-    rootDir,
-    prepareRootDir: () => prepareRootDir(rootDir),
-    writePaths: (paths: string[]) => writePaths(rootDir, paths),
-    writeFile: (path: string, content?: string) => writeFile(rootDir, path, content),
-    debug: () => debug(rootDir),
+    basePath,
+    prepareRootDir: () => prepareRootDir(basePath),
+    writePaths: (paths: string[]) => writePaths(basePath, paths),
+    writeFile: (path: string, content?: string) => writeFile(basePath, path, content),
+    debug: () => debug(basePath),
   };
 }
 
-function writePaths(rootDir: string, paths: string[]) {
+function writePaths(basePath: string, paths: string[]) {
   paths.forEach((path) => {
     if (path.endsWith("/")) {
-      fs.mkdirSync(nodePath.join(rootDir, path), { recursive: true });
+      fs.mkdirSync(nodePath.join(basePath, path), { recursive: true });
     } else {
-      writeFile(rootDir, path);
+      writeFile(basePath, path);
     }
   });
 }
 
-function writeFile(rootDir: string, path: string, content: string = "Hello, world!") {
-  const absolutePath = nodePath.join(rootDir, path);
+function writeFile(basePath: string, path: string, content: string = "Hello, world!") {
+  const absolutePath = nodePath.join(basePath, path);
   const absoluteDirPath = nodePath.dirname(absolutePath);
   fs.mkdirSync(absoluteDirPath, { recursive: true });
   fs.writeFileSync(absolutePath, content);
 }
 
-function prepareRootDir(rootDir: string) {
-  if (fs.existsSync(rootDir)) {
-    fs.rmSync(rootDir, { recursive: true });
+function prepareRootDir(basePath: string) {
+  if (fs.existsSync(basePath)) {
+    fs.rmSync(basePath, { recursive: true });
   }
 
-  fs.mkdirSync(rootDir, { recursive: true });
+  fs.mkdirSync(basePath, { recursive: true });
 }
 
-function debug(rootDir: string) {
+function debug(basePath: string) {
   function printDir(dir: string, prefix: string) {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
     entries.forEach((entry) => {
@@ -52,5 +52,5 @@ function debug(rootDir: string) {
     });
   }
 
-  printDir(rootDir, "");
+  printDir(basePath, "");
 }


### PR DESCRIPTION
## What does this PR do?

Based on the experience so far, improve input API. This is a breaking change.

## Relevant implementation details

Use ESLint option names instead of TSC options:
- `rootDir` => `basePath`
- `include` => `files`
- `exclude` => `ignores`
- `extraInputs` => `contentInputs`

## How did you test this?

All tests should pass. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Core API and option keys renamed for consistency (rootDir → basePath; include → files; exclude → ignores; extraInputs → contentInputs); several function/return names updated (e.g., remapPaths → rebasePath, hashContent → hashData).
- New Features
  - Added content helpers (textContent, jsonContent, envContent), exported content-hashing helpers, new sortBy and test-format helper.
- Documentation
  - README updated to reflect new option names, concurrency option, examples, and API signatures.
- Chores
  - CI workflow renamed from “Check Package Size” to “Package Size”.
- Tests
  - Test suites and utilities updated to use basePath and renamed options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->