### PR TITLE
feat: `gitIgnore` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ interface Fingerprint {
 }
 ```
 
+Note: when using `gitIgnore` option, it silently ignores any git invocation errors (e.g. missing `git` binary, or not a git repository).
+
 ### `calculateFingerprintSync`
 
 ```ts

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -263,6 +263,58 @@ describe("calculateFingerprint", () => {
     expect(fingerprintSync).toEqual(fingerprint);
   });
 
+  test("supports both files, ignores patterns, and .gitignore", async () => {
+    writePaths([
+      "file-1.txt",
+      "file-2.md",
+      "dir-1/file-3.txt",
+      "dir-1/file-4.md",
+      "dir-2/file-5.txt",
+      "dir-2/nested/file-6.txt",
+      "dir-2/nested/file-7.md",
+      "dir-3/file-8.txt",
+    ]);
+
+    writeFile(".gitignore", "dir-2/nested");
+    execSync("git init", { cwd: basePath });
+
+    const options: FingerprintOptions = {
+      files: ["file-1.txt", "dir-1/", "dir-2"],
+      ignores: ["**/*.md"],
+      gitIgnore: true,
+    };
+
+    const fingerprint = await calculateFingerprint(basePath, options);
+    expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
+      "Hash: 1cb4f6d53cae1ab8068780c4e64cd4db9eabed45
+      Files:
+      - dir-1/file-3.txt - 943a702d06f34599aee1f8da8ef9f7296031d699
+      - dir-2/file-5.txt - 943a702d06f34599aee1f8da8ef9f7296031d699
+      - file-1.txt - 943a702d06f34599aee1f8da8ef9f7296031d699
+      Content:
+      "
+    `);
+
+    expect(findFile(fingerprint, "file-1.txt")).toBeTruthy();
+    expect(findFile(fingerprint, "dir-1/file-3.txt")).toBeTruthy();
+    expect(findFile(fingerprint, "dir-2/file-5.txt")).toBeTruthy();
+
+    expect(findFile(fingerprint, "file-2.md")).toBeNull();
+    expect(findFile(fingerprint, "dir-1/file-4.md")).toBeNull();
+    expect(findFile(fingerprint, "dir-2/nested/file-6.md")).toBeNull();
+    expect(findFile(fingerprint, "dir-3/file-8.txt")).toBeNull();
+
+    const fingerprintSync = calculateFingerprintSync(basePath, options);
+    expect(fingerprintSync).toEqual(fingerprint);
+
+    const gitIgnores = getGitIgnoredPaths(basePath);
+    expect(gitIgnores).toMatchInlineSnapshot(`
+      [
+        "dir-2/nested/",
+      ]
+    `);
+  });
+
   test("follows symlinks", async () => {
     writePaths(["file1.txt", "dir-1/"]);
     fs.symlinkSync(
@@ -357,31 +409,16 @@ describe("calculateFingerprint", () => {
     writePaths(PATHS_TXT.map((p) => path.join("pkg/b", p)));
     writePaths(PATHS_MD.map((p) => path.join("pkg/b", p)));
     writePaths(["root-file.txt", "root-file.md"]);
+
     writeFile(".gitignore", "*.md");
-
-    execSync("git init", {
-      cwd: basePath,
-    });
-
-    const packageRootPath = path.join(basePath, "pkg/a");
-    const ignoredPaths = getGitIgnoredPaths(packageRootPath, { entireRepo: true });
-    expect(ignoredPaths).toMatchInlineSnapshot(`
-      [
-        "../../root-file.md",
-        "../b/dir/file2.md",
-        "../b/dir/subdir/file3.md",
-        "../b/file1.md",
-        "dir/file2.md",
-        "dir/subdir/file3.md",
-        "file1.md",
-      ]
-    `);
+    execSync("git init", { cwd: basePath });
 
     const options: FingerprintOptions = {
       files: ["**/*.txt", "../../pkg/b", "../../root-file.*"],
-      ignores: ignoredPaths,
+      gitIgnore: true,
     };
 
+    const packageRootPath = path.join(basePath, "pkg/a");
     const fingerprint = await calculateFingerprint(packageRootPath, options);
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 517f0f053c6726df50bdf41e4d2f2f1f8c58feca
@@ -414,5 +451,18 @@ describe("calculateFingerprint", () => {
 
     const fingerprintSync = calculateFingerprintSync(packageRootPath, options);
     expect(fingerprintSync).toEqual(fingerprint);
+
+    const gitIgnores = getGitIgnoredPaths(packageRootPath, { entireRepo: true });
+    expect(gitIgnores).toMatchInlineSnapshot(`
+      [
+        "../../root-file.md",
+        "../b/dir/file2.md",
+        "../b/dir/subdir/file3.md",
+        "../b/file1.md",
+        "dir/file2.md",
+        "dir/subdir/file3.md",
+        "file1.md",
+      ]
+    `);
   });
 });

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -474,9 +474,7 @@ describe("calculateFingerprint", () => {
       gitIgnore: true,
     };
 
-    const consoleWarnMock = spyOn(console, "warn").mockReset();
     const fingerprint = await calculateFingerprint(basePath, options);
-    expect(console.warn).toHaveBeenCalledWith("Failed to get git ignored files.");
 
     expect(formatFingerprint(fingerprint)).toMatchInlineSnapshot(`
       "Hash: 56823b8e45505714e2b19db32f88c66af87b139b
@@ -492,9 +490,7 @@ describe("calculateFingerprint", () => {
     expect(findFile(fingerprint, "dir/file2.md")).toBeTruthy();
     expect(findFile(fingerprint, "dir/subdir/file3.md")).toBeTruthy();
 
-    consoleWarnMock.mockReset();
     const fingerprintSync = calculateFingerprintSync(basePath, options);
-    expect(console.warn).toHaveBeenCalledWith("Failed to get git ignored files.");
     expect(fingerprintSync).toEqual(fingerprint);
 
     expect(() => getGitIgnoredPaths(basePath)).toThrowError(/Failed to get git ignored files./);

--- a/src/__tests__/fingerprint.test.ts
+++ b/src/__tests__/fingerprint.test.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import { findData, findFile } from "../../test-utils/assert.js";
 import { formatFingerprint } from "../../test-utils/format.js";

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -49,6 +49,12 @@ function resolveIgnores(
   }
 
   const hasOutsidePaths = options?.files?.some((pattern) => pattern.startsWith("..")) ?? false;
-  const gitIgnores = getGitIgnoredPaths(basePath, { entireRepo: hasOutsidePaths });
+  let gitIgnores: string[] = [];
+  try {
+    gitIgnores = getGitIgnoredPaths(basePath, { entireRepo: hasOutsidePaths });
+  } catch {
+    console.warn("Failed to get git ignored files.");
+    // Intentionally ignore git errors
+  }
   return options?.ignores ? [...gitIgnores, ...options.ignores] : gitIgnores;
 }

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -1,3 +1,4 @@
+import { getGitIgnoredPaths } from "./git.js";
 import { calculateContentHash } from "./inputs/content.js";
 import { calculateFileHash, calculateFileHashSync } from "./inputs/file.js";
 import type { Config, Fingerprint, FingerprintOptions } from "./types.js";
@@ -5,13 +6,15 @@ import { getInputFiles, getInputFilesSync, mergeHashes } from "./utils.js";
 
 export async function calculateFingerprint(
   basePath: string,
-  { hashAlgorithm, files, ignores, contentInputs }: FingerprintOptions = {},
+  options?: FingerprintOptions,
 ): Promise<Fingerprint> {
+  const { hashAlgorithm, files, contentInputs } = options ?? {};
   const config: Config = {
     basePath,
     hashAlgorithm,
   };
 
+  const ignores = resolveIgnores(basePath, options);
   const inputFiles = await getInputFiles(basePath, { files, ignores });
   const fileHashes = await Promise.all(inputFiles.map((path) => calculateFileHash(path, config)));
 
@@ -21,16 +24,31 @@ export async function calculateFingerprint(
 
 export function calculateFingerprintSync(
   basePath: string,
-  { hashAlgorithm, files, ignores, contentInputs }: FingerprintOptions = {},
+  options?: FingerprintOptions,
 ): Fingerprint {
+  const { hashAlgorithm, files, contentInputs } = options ?? {};
   const config: Config = {
     basePath,
     hashAlgorithm,
   };
 
+  const ignores = resolveIgnores(basePath, options);
   const inputFiles = getInputFilesSync(basePath, { files, ignores });
   const fileHashes = inputFiles.map((path) => calculateFileHashSync(path, config));
 
   const contentHashes = contentInputs?.map((input) => calculateContentHash(input, config)) ?? [];
   return mergeHashes(fileHashes, contentHashes, config);
+}
+
+function resolveIgnores(
+  basePath: string,
+  options?: FingerprintOptions,
+): readonly string[] | undefined {
+  if (!options?.gitIgnore) {
+    return options?.ignores;
+  }
+
+  const hasOutsidePaths = options?.files?.some((pattern) => pattern.startsWith("..")) ?? false;
+  const gitIgnores = getGitIgnoredPaths(basePath, { entireRepo: hasOutsidePaths });
+  return options?.ignores ? [...gitIgnores, ...options.ignores] : gitIgnores;
 }

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -53,8 +53,8 @@ function resolveIgnores(
   try {
     gitIgnores = getGitIgnoredPaths(basePath, { entireRepo: hasOutsidePaths });
   } catch {
-    console.warn("Failed to get git ignored files.");
     // Intentionally ignore git errors
   }
+
   return options?.ignores ? [...gitIgnores, ...options.ignores] : gitIgnores;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,19 +8,19 @@ type StringWithAutoSuggest<T> = (string & {}) | T;
 export type HashAlgorithm = StringWithAutoSuggest<"sha1" | "sha256" | "sha512">;
 
 export interface FingerprintOptions {
-  /** Glob patterns indicating files (and directories) to include */
+  /** Glob patterns indicating files (and directories) to include (default: '**' - all) */
   files?: readonly string[];
 
-  /** Glob patterns indicating files (and directories) to ignore */
+  /** Glob patterns indicating files (and directories) to ignore (default: none) */
   ignores?: readonly string[];
 
-  /** Extra inputs to include in the fingerprint: text, json, etc */
+  /** Extra inputs to include in the fingerprint: text, json, etc (default: none) */
   contentInputs?: readonly ContentInput[];
 
-  /** Hashing algorithm to use */
+  /** Hashing algorithm to use (default: "sha1") */
   hashAlgorithm?: HashAlgorithm;
 
-  /** Whether to ignore files ignored by Git */
+  /** Whether to ignore files ignored by Git (default: false) */
   gitIgnore?: boolean;
 }
 
@@ -33,14 +33,31 @@ export interface Config {
 }
 
 export interface ContentInput {
+  /** The key to identify the content */
   key: string;
+
+  /** The content to hash */
   content: string;
+
+  /**
+   * Whether to omit the clear-text content from the fingerprint manifest.
+   * It will still be included in the fingerprint hash.
+   * (default: false)
+   * */
   secret?: boolean;
 }
 
+/**
+ * Unique fingerprint hash representing the matched files paths and content, as well as passed content inputs
+ * */
 export interface Fingerprint {
+  /** The fingerprint hash */
   hash: string;
+
+  /** Files included in the fingerprint hash */
   files: FileHash[];
+
+  /** Content included in the fingerprint hash */
   content: ContentHash[];
 }
 
@@ -52,5 +69,6 @@ export interface FileHash {
 export interface ContentHash {
   key: string;
   hash: string;
+
   content?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,9 @@ export interface FingerprintOptions {
 
   /** Hashing algorithm to use */
   hashAlgorithm?: HashAlgorithm;
+
+  /** Whether to ignore files ignored by Git */
+  gitIgnore?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Add `gitIgnore` option to `calculcateFingerprint` (+ sync) to automatically add `.gitignore` contents.

## Relevant implementation details

Detects paths outside `basePath` and uses `entireRepo` option to `getGitIgnoredPaths`.

## How did you test this?

More automated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a gitIgnore option to fingerprinting APIs (sync and async) and optional inclusion of file content in fingerprint results.

* **Documentation**
  * Moved Git-ignored paths API to Low-level APIs; examples updated to use gitIgnore: true. Added note about Git invocation errors being silenced when gitIgnore is used and minor editorial tweaks.

* **Tests**
  * Added tests for .gitignore handling, combined file/ignore scenarios, and Git error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->