### PR TITLE
chore: ESM-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "main": "dist/index.js",
   "exports": {
     "types": "./dist/index.d.ts",
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    "default": "./dist/index.js"
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["esm", "cjs"],
+  format: ["esm"],
   dts: true,
   clean: true,
 });


### PR DESCRIPTION
## What does this PR do?

Remove CommonJS output.

## Relevant implementation details

## How did you test this?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Switched build to ESM-only; CommonJS output removed.
  - Updated package exports to use a single default entry.
  - Marked package as side-effect free to improve tree-shaking.

- Breaking Changes
  - CommonJS consumers (require) are no longer supported. Use ESM imports (import ... from 'package').

- Impact
  - Smaller bundles and better tree-shaking for ESM users.
  - Consumers relying on CJS must migrate to ESM or use a compatible bundling setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->