### PR TITLE
docs: api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,28 +134,6 @@ const { hash } = calculateFingerprintSync("/project/path", { ...options });
 4. **Benchmark Everything:**
    Do not make assumptions about what is fast and what is not, always benchmark any introduced code changes.
 
-## Low-level APIs
-
-### `getGitIgnoredPaths`
-
-```ts
-function getGitIgnoredPaths(
-  basePath: string, // Base path to look for git ignored paths
-  options?: {
-    entireRepo?: boolean; // Search for ignored paths in the whole repo (default: false)
-  },
-): string[];
-```
-
-Helper to get paths ignored by Git from `.gitignore` and other Git settings.  
-This function invokes `git ls-files`, so Git must be installed and available in PATH.
-
-**Note:** This function may throw errors (e.g., not a git repository). Use `try/catch` to handle errors.
-
-#### Options
-
-- `entireRepo`: If `basePath` is not the git root, set this to search the entire repository. Always returns paths relative to `basePath`.
-
 ## Contributing
 
 PRs welcome! Keep it awesome.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const { hash } = await calculateFingerprint("/project/path", {
 });
 ```
 
-## API Reference
+## Core API
 
 ### `calculateFingerprint`
 
@@ -65,28 +65,7 @@ interface Fingerprint {
 
 Note: when using `gitIgnore` option, it silently ignores any git invocation errors (e.g. missing `git` binary, or not a git repository).
 
-### `calculateFingerprintSync`
-
-```ts
-function calculateFingerprintSync(
-  basePath: string, // Base path to resolve "files" and "ignores" patterns
-  options?: {
-    files?: string[]; // Glob patterns to include (default: all)
-    ignores?: string[]; // Glob patterns to exclude (default: none)
-    contentInputs?: ContentInput[]; // Additional inputs: text, JSON, envs, etc.
-    hashAlgorithm?: string; // Hash algorithm (default: "sha1")
-    gitIgnore?: boolean;
-  },
-): Fingerprint;
-```
-
-Sync version of `calculateFingerprint`:
-
-- Generates the same hash value without `await`
-- Performance considerations:
-  - on M3 MacBook Pro the async version is 2x faster
-  - on Intel Mac both async and sync versions are comparable
-  - on GitHub CI runner (`ubuntu-latest`) the sync version is 2x faster(!)
+Browser [API Reference](./docs/API.md) for other API.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ interface Fingerprint {
 
 Note: when using `gitIgnore` option, it silently ignores any git invocation errors (e.g. missing `git` binary, or not a git repository).
 
-Browser [API Reference](./docs/API.md) for other API.
+Browse the [API Reference](./docs/API.md) for other API.
 
 ## Examples
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,82 @@
+# API Reference
+
+FS Fingerprint API consists of two levels: high-level and low-level APIs.
+
+## High-level APIs
+
+### `calculateFingerprint`
+
+```ts
+async function calculateFingerprint(
+  basePath: string, // Base path to resolve "files" and "ignores" patterns
+  options?: {
+    files?: string[]; // Glob patterns to include (default: all)
+    ignores?: string[]; // Glob patterns to exclude (default: none)
+    contentInputs?: ContentInput[]; // Additional inputs: text, JSON, envs, etc.
+    hashAlgorithm?: string; // Hash algorithm (default: "sha1")
+  },
+): Promise<Fingerprint>;
+```
+
+Generates a fingerprint hash for the filesystem state.
+
+**Return Value**
+
+```typescript
+interface Fingerprint {
+  hash: string; // Overall project fingerprint hash
+  files: FileHash[]; // File hashes included in the fingerprint
+  content: ContentHash[]; // Content hashes included in the fingerprint
+}
+```
+
+### `calculateFingerprintSync`
+
+```ts
+function calculateFingerprintSync(
+  basePath: string, // Base path to resolve "files" and "ignores" patterns
+  options?: {
+    files?: string[]; // Glob patterns to include (default: all)
+    ignores?: string[]; // Glob patterns to exclude (default: none)
+    contentInputs?: ContentInput[]; // Additional inputs: text, JSON, envs, etc.
+    hashAlgorithm?: string; // Hash algorithm (default: "sha1")
+  },
+): Fingerprint;
+```
+
+**Return Value**
+
+```typescript
+interface Fingerprint {
+  hash: string; // Overall project fingerprint hash
+  files: FileHash[]; // File hashes included in the fingerprint
+  content: ContentHash[]; // Content hashes included in the fingerprint
+}
+```
+
+**Performance considerations**
+In general async version should be faster due ability to read many files at the same time. However, in practices it has been observed as true on high-end machines, e.g. MacBook Pro.
+
+On standard GitHub CI runner (`ubuntu-latest`) the sync version is 2x faster(!)
+
+## Low-level API
+
+### `getGitIgnoredPaths`
+
+```ts
+function getGitIgnoredPaths(
+  basePath: string, // Base path to look for git ignored paths
+  options?: {
+    entireRepo?: boolean; // Search for ignored paths in the whole repo (default: false)
+  },
+): string[];
+```
+
+Helper to get paths ignored by Git from `.gitignore` and other Git settings.  
+This function invokes `git ls-files`, so Git must be installed and available in PATH.
+
+**Note:** This function may throw errors (e.g., not a git repository). Use `try/catch` to handle errors.
+
+#### Options
+
+- `entireRepo`: If `basePath` is not the git root, set this to search the entire repository. Always returns paths relative to `basePath`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -57,7 +57,7 @@ interface Fingerprint {
 **Performance considerations**
 In general async version should be faster due ability to read many files at the same time. However, in practices it has been observed as true on high-end machines, e.g. MacBook Pro.
 
-On standard GitHub CI runner (`ubuntu-latest`) the sync version is 2x faster(!)
+On standard GitHub CI runners (`ubuntu-latest`), the sync version is 2x faster(!) than the async version.
 
 ## Low-level APIs
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -59,7 +59,7 @@ In general async version should be faster due ability to read many files at the 
 
 On standard GitHub CI runner (`ubuntu-latest`) the sync version is 2x faster(!)
 
-## Low-level API
+## Low-level APIs
 
 ### `getGitIgnoredPaths`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,8 +54,9 @@ interface Fingerprint {
 }
 ```
 
-**Performance considerations**
-In general async version should be faster due ability to read many files at the same time. However, in practices it has been observed as true on high-end machines, e.g. MacBook Pro.
+#### Performance considerations
+
+In general, the async version should be faster due to its ability to read many files at the same time. However, in practice this has been mostly observed on high-end machines, e.g. MacBook Pro.
 
 On standard GitHub CI runners (`ubuntu-latest`), the sync version is 2x faster(!) than the async version.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 export { calculateFingerprint, calculateFingerprintSync } from "./fingerprint.js";
-export { calculateFileHash, calculateFileHashSync } from "./inputs/file.js";
-export { calculateContentHash, textContent, jsonContent, envContent } from "./inputs/content.js";
+export { textContent, jsonContent, envContent } from "./inputs/content.js";
 export { getGitIgnoredPaths } from "./git.js";
-export { hashData, mergeHashes } from "./utils.js";
 
 export type * from "./types.js";


### PR DESCRIPTION
## What does this PR do?

Simplify README, by moving API reference to separate file.
Restrict exports only to documented functions.

## Relevant implementation details

## How did you test this?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - Removed several low-level hashing utilities from the public API; rely on the high-level fingerprint APIs and content helpers instead.

- Documentation
  - Added a comprehensive API reference describing the public fingerprint APIs.
  - Renamed “API Reference” to “Core API” and moved/updated sync-related docs.
  - Updated examples and README to remove sync usage and emphasize async usage with a reference link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->